### PR TITLE
update CI to let setup-node choose version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-          cache: npm
+          #cache: npm
       - uses: actions/checkout@v4
       - run: |
           npm install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,13 +3,10 @@ on: [push, pull_request]
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16]
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 'lts/*'
           cache: npm
       - uses: actions/checkout@v4
       - run: |


### PR DESCRIPTION
## Description

update CI to let setup-node choose version

## Related Issue

- closes https://github.com/stac-extensions/mlm/pull/2

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :books: Examples, docs, tutorials or dependencies update;
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](../CONTRIBUTING.md) guide;
- [ ] I've updated the code style using `make check`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
