### PR TITLE
adjust remark config to aligh `check-markdown` with `format-markdown` outputs

### DIFF
--- a/.github/remark.yaml
+++ b/.github/remark.yaml
@@ -1,3 +1,11 @@
+settings:
+  listItemIndent: '1'
+  emphasis: '*'
+  spacedTable: false
+  paddedTable: true
+  stringify:
+    entities: false
+    escape: false
 plugins:
 # Check links
   - validate-links
@@ -14,8 +22,11 @@ plugins:
   - remark-lint-no-consecutive-blank-lines
   - - remark-lint-maximum-line-length
     - 120
+  - remark-lint-no-literal-urls
 # GFM - autolink literals, footnotes, strikethrough, tables, tasklist
   - remark-gfm
+# Math Expression
+  - remark-math
 # Code
   - remark-lint-fenced-code-flag
   - remark-lint-fenced-code-marker
@@ -33,14 +44,17 @@ plugins:
   - - remark-lint-no-shortcut-reference-link
     - false
 # Lists
-  - remark-lint-list-item-bullet-indent
+  - - remark-lint-list-item-bullet-indent
+    - 'one'
   - remark-lint-ordered-list-marker-style
   - remark-lint-ordered-list-marker-value
   - remark-lint-checkbox-character-style
   - - remark-lint-unordered-list-marker-style
     - '-'
+  - - remark-lint-list-item-content-indent
+    - 1
   - - remark-lint-list-item-indent
-    - space
+    - 'space'
 # Tables
   - remark-lint-table-pipes
-  - remark-lint-no-literal-urls
+  - remark-lint-table-cell-padding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/stac-extensions/mlm/tree/main)
 
 ### Added
+
 - Add [`huggingface/safetensors`](https://github.com/huggingface/safetensors)
-  recommendations for `mlm:artifact_type` and corresponding ``mlm:framework`` values
+  recommendations for `mlm:artifact_type` and corresponding `mlm:framework` values
   (fixes [#68](https://github.com/stac-extensions/mlm/issues/68)).
 - Add [`Flax`](https://github.com/google/flax) to the list of `mlm:framework` and
   the corresponding `mlm:artifact_type` SafeTensors backend in the JSON schema examples.
@@ -17,20 +18,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (fixes [#69](https://github.com/stac-extensions/mlm/issues/69)).
 
 ### Changed
+
 - Update `stac-model==0.3.0` to provide `ValueScalingObject` from installed package.
 
 ### Deprecated
+
 - n/a
 
 ### Removed
+
 - n/a
 
 ### Fixed
+
 - n/a
 
 ## [v1.4.0](https://github.com/stac-extensions/mlm/tree/v1.4.0)
 
 ### Added
+
 - Add better descriptions about required and recommended *MLM Asset Roles* and
   their implications (fixes
   [#54](https://github.com/stac-extensions/mlm/issues/54)).
@@ -44,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for Ahead of Time Compilation, `jit` for Just-In Time Compilation.
 
 ### Changed
+
 - Explicitly disallow `mlm:name`, `mlm:input`, `mlm:output` and `mlm:hyperparameters` at the Asset level.
   These fields describe the model as a whole and should therefore be defined in Item properties.
 - Moved `norm_type` to `value_scaling` object to better reflect the expected operation, which could be another
@@ -54,9 +61,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - expanded suggested `mlm:artifact_type` values to include Tensorflow/Keras.
 
 ### Deprecated
+
 - n/a
 
 ### Removed
+
 - Removed `norm_type` enum values that were ambiguous regarding their expected result.
   Instead, a `processing:expression` should be employed to explicitly define the calculation they represent.
 - Removed `norm_clip` property. It is now represented under `value_scaling` objects with a
@@ -66,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Otherwise, the amount of `value_scaling` objects should match the number of bands or channels involved in the input.
 
 ### Fixed
+
 - Fix missing `mlm:artifact_type` property check for a Model Asset definition
   (fixes <https://github.com/stac-extensions/mlm/issues/42>).
   The `mlm:artifact_type` is now mutually and exclusively required by the corresponding Asset with `mlm:model` role.
@@ -75,11 +85,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.3.0](https://github.com/stac-extensions/mlm/tree/v1.3.0)
 
 ### Added
+
 - Add `raster:bands` required property `name` for describing `mlm:input` bands
   (see [README - Bands and Statistics](README.md#bands-and-statistics) for details).
 - Add README warnings about new extension `eo` and `raster` versions.
 
 ### Changed
+
 - Split `ModelBands` and `AnyBandsRef` definitions in the JSON schema to allow them to be referenced individually.
 - Move `AnyBandsRef` definition explicitly to STAC Item JSON schema, rather than implicitly inferred via `mlm:input`.
 - Modified the JSON schema to use a `if` check of the `type` (STAC Item or Collection) prior to validating further
@@ -87,15 +99,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to fail, rather than reporting the first mismatching `type` case with a poor error description to debug the issue.
 
 ### Deprecated
+
 - n/a
 
 ### Removed
+
 - Removed `$comment` entries from the JSON schema that are considered as invalid by some parsers.
 - When `mlm:input` objects do **NOT** define band references (i.e.: `bands: []` is used), the JSON schema will not
   fail if an Asset with the `mlm:model` role contains a band definition. This is to allow MLM model definitions to
   simultaneously use some inputs with `bands` reference names while others do not.
 
 ### Fixed
+
 - Band checks against [`eo`](https://github.com/stac-extensions/eo), [`raster`](https://github.com/stac-extensions/eo)
   or STAC Core 1.1 [`bands`](https://github.com/radiantearth/stac-spec/blob/master/commons/common-metadata.md#bands)
   when a `mlm:input` references names in `bands` are now properly validated.
@@ -110,24 +125,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.2.0](https://github.com/stac-extensions/mlm/tree/v1.2.0)
 
 ### Added
+
 - Add the missing JSON schema `item_assets` definition under a Collection to ensure compatibility with
   the [Item Assets](https://github.com/stac-extensions/item-assets) extension, as mentioned this specification.
 - Add `ModelBand` representation using `name`, `format` and `expression` properties to allow derived band references
   (fixes [crim-ca/mlm-extension#7](https://github.com/stac-extensions/mlm/discussions/7)).
 
 ### Changed
+
 - Adds a job to `.github/workflows/publish.yaml` to publish the `stac-model` package to PyPI.
 
 ### Deprecated
+
 - n/a
 
 ### Removed
+
 - Field `mlm:name` requirement to be unique. There is no way to guarantee this from a single Item's definition
   and their JSON schema validation. For uniqueness requirement, users should instead rely on the `id` property
   of the Item, which is ensured to be unique under the corresponding Collection, since it would not be retrievable
   otherwise (i.e.: `collections/{collectionID}/items/{itemID}`).
 
 ### Fixed
+
 - Fix the validation strategy of the `mlm:model` role required by at least one Asset under a STAC Item.
   Although the role requirement was validated, the definition did not allow for other Assets without it to exist.
 - Correct `stac-model` version in code and publish matching release on PyPI.
@@ -135,6 +155,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.1.0](https://github.com/stac-extensions/mlm/tree/v1.1.0)
 
 ### Added
+
 - Add pattern for `mlm:framework`, needing at least one alphanumeric character,
   without leading or trailing non-alphanumeric characters.
 - Add [`examples/item_eo_and_raster_bands.json`](examples/item_eo_and_raster_bands.json) demonstrating the original
@@ -142,15 +163,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a `description` field for `mlm:input` and `mlm:output` definitions.
 
 ### Changed
+
 - Adjust `scikit-learn` and `Hugging Face` framework names to match the format employed by the official documentation.
 
 ### Deprecated
+
 - n/a
 
 ### Removed
+
 - Removed combination of `mlm:input` with `bands: null` that could never occur due to pre-requirement of `type: array`.
 
 ### Fixed
+
 - Fix `AnyBands` definition and use in the JSON schema to better consider possible use cases with `eo` extension.
 - Fix [`examples/item_eo_bands.json`](examples/item_eo_bands.json) that was incorrectly also using `raster` extension.
   This is not fundamentally wrong, but it did not allow to validate the `eo` extension use case properly, since
@@ -159,6 +184,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.0.0](https://github.com/stac-extensions/mlm/tree/v1.0.0)
 
 ### Added
+
 - more [Task Enum](README.md#task-enum) tasks
 - [Model Output Object](README.md#model-output-object)
 - `batch_size` and hardware summary
@@ -172,6 +198,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pixel-wise and patch-based classification
 
 ### Changed
+
 - `disk_size` replaced by `file:size` (see [Best Practices - File Extension](best-practices.md#file-extension))
 - `memory_size` under `dlm:architecture` moved directly under Item properties as `mlm:memory_size`
 - replaced all hardware/accelerator/runtime definitions into distinct `mlm` fields directly under the
@@ -191,13 +218,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - updated JSON schema to reflect changes of MLM fields
 
 ### Deprecated
+
 - any `dlm`-prefixed field or property
 
 ### Removed
+
 - Data Object, replaced with [Model Input Object](./README.md#model-input-object) that uses the `name` field from
   the [common metadata band object][stac-bands] which also records `data_type` and `nodata` type
 
 ### Fixed
+
 - n/a
 
 [stac-bands]: https://github.com/radiantearth/stac-spec/blob/f9b3c59ba810541c9da70c5f8d39635f8cba7bcd/item-spec/common-metadata.md#bands
@@ -205,9 +235,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.0.0-beta3](https://github.com/crim-ca/dlm-extension/tree/v1.0.0-beta3)
 
 ### Added
+
 - Added example model architecture summary text.
 
 ### Changed
+
 - Modified `$id` if the extension schema to refer to the expected location when eventually released
   (`https://schemas.stacspec.org/v1.0.0-beta.3/extensions/dl-model/json-schema/schema.json`).
 - Replaced `dtype` field by `data_type` to better align with the corresponding field of
@@ -223,16 +255,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [raster-band-object]: https://github.com/stac-extensions/raster/#raster-band-object
 
 ### Deprecated
+
 - Specifying `class_name_mapping` by array is deprecated.
   Direct mapping as an object of index to class name should be used.
   For backward compatibility, mapping as array and using nested objects with `index` and `class_name` properties
   is still permitted, although overly verbose compared to the direct mapping.
 
 ### Removed
+
 - Field `nodata_value`.
 - Field `dtype`.
 
 ### Fixed
+
 - Fixed references to other STAC extensions to use the official schema links on `https://stac-extensions.github.io/`.
 - Fixed examples to refer to local files.
 - Fixed formatting of tables and descriptions in README.
@@ -240,16 +275,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.0.0-beta2](https://github.com/crim-ca/dlm-extension/tree/v1.0.0-beta2)
 
 ### Added
+
 - Initial release of the extension description and schema.
 
 ### Changed
+
 - n/a
 
 ### Deprecated
+
 - n/a
 
 ### Removed
+
 - n/a
 
 ### Fixed
+
 - n/a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,55 +4,57 @@
 
 1. If you don't have `uv` installed run:
 
-```bash
-make setup
-```
+   ```bash
+   make setup
+   ```
 
-> This installs `uv` as a [standalone application][uv-install]. <br>
-> For more details, see also the [`uv` documentation][uv-docs]. <br>
+   This installs `uv` as a [standalone application][uv-install]. <br>
+   For more details, see also the [`uv` documentation][uv-docs].
 
 2. Initialize project dependencies with `uv` and install `pre-commit` hooks:
 
-```bash
-make install-dev
-make pre-commit-install
-```
+   ```bash
+   make install-dev
+   make pre-commit-install
+   ```
 
-This will install project dependencies into the currently active environment. If you would like to
-use uv's default behavior of managing a project-scoped environment, use `uv` commands directly to
-install dependencies. `uv sync` will install dependencies and dev dependencies in `.venv` and update the `uv.lock`.
+   This will install project dependencies into the currently active environment. If you would like to
+   use `uv`'s default behavior of managing a project-scoped environment, use `uv` commands directly to
+   install dependencies. `uv sync` will install dependencies and dev dependencies in `.venv` and update the `uv.lock`.
 
 ## PR submission
 
 Before submitting your code please do the following steps:
 
 1. Add any changes you want
+
 2. Add tests for the new changes
+
 3. Edit documentation if you have changed something significant
 
-You're then ready to run and test your contributions.
+   You're then ready to run and test your contributions.
 
 4. Run linting checks:
 
-```bash
-make lint-all
-```
+   ```bash
+   make lint-all
+   ```
 
 5. Run `tests` (including your new ones) with
 
-```bash
-make test
-```
+   ```bash
+   make test
+   ```
 
 6. Upload your changes to your fork, then make a PR from there to the main repo:
 
-```bash
-git checkout -b your-branch
-git add .
-git commit -m ":tada: Initial commit"
-git remote add origin https://github.com/your-fork/mlm-extension.git
-git push -u origin your-branch
-```
+   ```bash
+   git checkout -b your-branch
+   git add .
+   git commit -m ":tada: Initial commit"
+   git remote add origin https://github.com/your-fork/mlm-extension.git
+   git push -u origin your-branch
+   ```
 
 ## Building and releasing
 
@@ -60,6 +62,7 @@ git push -u origin your-branch
 
 > [!WARNING]
 > There are multiple types of releases for this repository: <br>
+>
 > 1. Release for MLM specification (usually, this should include one for `stac-model` as well to support it)
 > 2. Release for `stac-model` only
 
@@ -80,6 +83,7 @@ git push -u origin your-branch
 <!-- lint disable no-undefined-references -->
 
 > [!WARNING]
+>
 > - Ensure the "Set as the latest release" option is selected :heavy_check_mark:.
 > - Ensure the diff ranges from the previous MLM version, and not an intermediate `stac-model` release.
 
@@ -99,6 +103,7 @@ git push -u origin your-branch
 <!-- lint disable no-undefined-references -->
 
 > [!WARNING]
+>
 > - Ensure the "Set as the latest release" option is deselected :x:.
 > - Ensure the diff ranges from the previous release of `stac-model`, not an intermediate MLM release.
 
@@ -114,5 +119,7 @@ not serve your needs with us in the GitHub Discussions or raise
 Issues for bugs.
 
 [uv-install]: https://docs.astral.sh/uv/getting-started/installation/
+
 [uv-docs]: https://docs.astral.sh/uv/
+
 [semver]: https://semver.org/

--- a/README.md
+++ b/README.md
@@ -442,23 +442,23 @@ Below are some notable common names recommended for use, but others can be emplo
 - `score`
 - `confidence`
 
-For example, a tensor of multiple RBG images represented as $B \times C \times H \times W$ should
+For example, a tensor of multiple RBG images represented as $`B \times C \times H \times W`$ should
 indicate `dim_order = ["batch", "channel", "height", "width"]`.
 
 #### Value Scaling Object
 
 Select one option from:
 
-| `type`       | Required Properties                             | Scaling Operation                        |
-|--------------|-------------------------------------------------|------------------------------------------|
-| `min-max`    | `minimum`, `maximum`                            | $(data - minimum) / (maximum - minimum)$ |
-| `z-score`    | `mean`, `stddev`                                | $(data - mean) / stddev$                 |
-| `clip`       | `minimum`, `maximum`                            | $\min(\max(data, minimum), maximum)$     |
-| `clip-min`   | `minimum`                                       | $\max(data, minimum)$                    |
-| `clip-max`   | `maximum`                                       | $\min(data, maximum)$                    |
-| `offset`     | `value`                                         | $data - value$                           |
-| `scale`      | `value`                                         | $data / value$                           |
-| `processing` | [Processing Expression](#processing-expression) | *according to `processing:expression`*   |
+| `type`       | Required Properties                             | Scaling Operation                          |
+| ------------ | ----------------------------------------------- | ------------------------------------------ |
+| `min-max`    | `minimum`, `maximum`                            | $`(data - minimum) / (maximum - minimum)`$ |
+| `z-score`    | `mean`, `stddev`                                | $`(data - mean) / stddev`$                 |
+| `clip`       | `minimum`, `maximum`                            | $`\min(\max(data, minimum), maximum)`$     |
+| `clip-min`   | `minimum`                                       | $`\max(data, minimum)`$                    |
+| `clip-max`   | `maximum`                                       | $`\min(data, maximum)`$                    |
+| `offset`     | `value`                                         | $`data - value`$                           |
+| `scale`      | `value`                                         | $`data / value`$                           |
+| `processing` | [Processing Expression](#processing-expression) | *according to `processing:expression`*     |
 
 When a scaling `type` approach is specified, it is expected that the parameters necessary
 to perform their calculation are provided for the corresponding input dimension data.
@@ -573,11 +573,11 @@ as for `regression`, `image-captioning`, `super-resolution` and some `generative
 
 #### Result Structure Object
 
-| Field Name | Type                                   | Description                                                                                                                                                                                                                    |
-|------------|----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| shape      | \[integer]                             | **REQUIRED** Shape of the n-dimensional result array (e.g.: $B \times H \times W$ or $B \times C$), possibly including a batch size dimension. The dimensions must either be greater than 0 or -1 to indicate a variable size. |
-| dim_order  | \[[Dimension Order](#dimension-order)] | **REQUIRED** Order of the `shape` dimensions by name for the result array.                                                                                                                                                     |
-| data_type  | [Data Type Enum](#data-type-enum)      | **REQUIRED** The data type of values in the n-dimensional array. For model outputs, this should be the data type of the result of the model inference  without extra post processing.                                          |
+| Field Name | Type                                   | Description                                                                                                                                                                                                                        |
+| ---------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| shape      | \[integer]                             | **REQUIRED** Shape of the n-dimensional result array (e.g.: $`B \times H \times W`$ or $`B \times C`$), possibly including a batch size dimension. The dimensions must either be greater than 0 or -1 to indicate a variable size. |
+| dim_order  | \[[Dimension Order](#dimension-order)] | **REQUIRED** Order of the `shape` dimensions by name for the result array.                                                                                                                                                         |
+| data_type  | [Data Type Enum](#data-type-enum)      | **REQUIRED** The data type of values in the n-dimensional array. For model outputs, this should be the data type of the result of the model inference  without extra post processing.                                              |
 
 #### Class Object
 

--- a/README.md
+++ b/README.md
@@ -408,15 +408,16 @@ and can use [Data Types from STAC 1.1 Core][stac-1.1-data-types] for later versi
 Both definitions should define equivalent values.
 
 [raster-data-types]: https://github.com/stac-extensions/raster?tab=readme-ov-file#data-types
+
 [stac-1.1-data-types]: https://github.com/radiantearth/stac-spec/blob/bands/item-spec/common-metadata.md#data-types
 
 #### Input Structure Object
 
-| Field Name | Type                                   | Description                                                                                                                                                                                                               |
-|------------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| shape      | \[integer]                             | **REQUIRED** Shape of the input n-dimensional array (e.g.: $B \times C \times H \times W$), including the batch size dimension. Each dimension must either be greater than 0 or -1 to indicate a variable dimension size. |
-| dim_order  | \[[Dimension Order](#dimension-order)] | **REQUIRED** Order of the `shape` dimensions by name.                                                                                                                                                                     |
-| data_type  | [Data Type Enum](#data-type-enum)      | **REQUIRED** The data type of values in the n-dimensional array. For model inputs, this should be the data type of the processed input supplied to the model inference function, not the data type of the source bands.   |
+| Field Name | Type                                   | Description                                                                                                                                                                                                                 |
+| ---------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| shape      | \[integer]                             | **REQUIRED** Shape of the input n-dimensional array (e.g.: $`B \times C \times H \times W`$), including the batch size dimension. Each dimension must either be greater than 0 or -1 to indicate a variable dimension size. |
+| dim_order  | \[[Dimension Order](#dimension-order)] | **REQUIRED** Order of the `shape` dimensions by name.                                                                                                                                                                       |
+| data_type  | [Data Type Enum](#data-type-enum)      | **REQUIRED** The data type of values in the n-dimensional array. For model inputs, this should be the data type of the processed input supplied to the model inference function, not the data type of the source bands.     |
 
 A common use of `-1` for one dimension of `shape` is to indicate a variable batch-size.
 However, this value is not strictly reserved for the `b` dimension.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![hackmd-github-sync-badge](https://hackmd.io/XveEXOukQ52ZdpUxT8maeA/badge)](https://hackmd.io/XveEXOukQ52ZdpUxT8maeA?both)
 
 - **Title:** Machine Learning Model Extension
-- **Identifier:** [https://stac-extensions.github.io/mlm/v1.4.0/schema.json](https://stac-extensions.github.io/mlm/v1.4.0/schema.json)
+- **Identifier:** <https://stac-extensions.github.io/mlm/v1.4.0/schema.json>
 - **Field Name Prefix:** mlm
 - **Scope:** Collection, Item, Asset, Links
 - **Extension Maturity Classification:** Candidate
@@ -56,6 +56,7 @@ The main objectives of the extension are:
    an inference service.
 
 Specifically, this extension records the following information to make ML models searchable and reusable:
+
 1. Sensor band specifications
 2. Model input transforms including resize and normalization
 3. Model output shape, data type, and its semantic interpretation
@@ -117,7 +118,7 @@ The fields in the table below can be used in these parts of STAC documents:
 [item-assets]: https://github.com/stac-extensions/item-assets
 
 | Field Name                                | Type                                                          | Description                                                                                                                                                                                                                                                                                 |
-|-------------------------------------------|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | mlm:name <sup>[\[1\]][1]</sup>            | string                                                        | **REQUIRED** A name for the model. This can include, but must be distinct, from simply naming the model architecture. If there is a publication or other published work related to the model, use the official name of the model.                                                           |
 | mlm:architecture                          | [Model Architecture](#model-architecture) string              | **REQUIRED** A generic and well established architecture name of the model.                                                                                                                                                                                                                 |
 | mlm:tasks                                 | \[[Task Enum](#task-enum)]                                    | **REQUIRED** Specifies the Machine Learning tasks for which the model can be used for. If multi-tasks outputs are provided by distinct model heads, specify all available tasks under the main properties and specify respective tasks in each [Model Output Object](#model-output-object). |
@@ -141,6 +142,7 @@ The fields in the table below can be used in these parts of STAC documents:
 [1]: #notes
 
 ### Notes
+
 <b><sup>[1][1]</sup> Fields allowed only in Item `properties`</b>
 
 <!-- lint disable no-undefined-references -->
@@ -168,6 +170,7 @@ in STAC Collections and the corresponding spatial and temporal fields in Items, 
 [Best Practices - Using STAC Common Metadata Fields for the ML Model Extension][stac-mlm-meta].
 
 [stac-mlm-meta]: best-practices.md#using-stac-common-metadata-fields-for-the-ml-model-extension
+
 [stac-extent]: https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#extent-object
 
 ### Model Architecture
@@ -191,7 +194,7 @@ definitions listed in [Papers With Code](https://paperswithcode.com/sota). The n
 should be normalized to lowercase and use hyphens instead of spaces.
 
 | Task Name               | Corresponding `label:tasks` | Description                                                                                                              |
-|-------------------------|-----------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| ----------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `regression`            | `regression`                | Generic regression that estimates a numeric and continuous value.                                                        |
 | `classification`        | `classification`            | Generic classification task that assigns class labels to an output.                                                      |
 | `scene-classification`  | *n/a*                       | Specific classification task where the model assigns a single class label to an entire scene/area.                       |
@@ -276,7 +279,7 @@ set to `true`, there would be no `accelerator` to contain against. To avoid conf
 ### Model Input Object
 
 | Field Name              | Type                                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                              |
-|-------------------------|----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | name                    | string                                                   | **REQUIRED** Name of the input variable defined by the model. If no explicit name is defined by the model, an informative name (e.g.: `"RGB Time Series"`) can be used instead.                                                                                                                                                                                                                                          |
 | bands                   | \[string \| [Model Band Object](#model-band-object)]     | **REQUIRED** The raster band references used to train, fine-tune or perform inference with the model, which may be all or a subset of bands available in a STAC Item's [Band Object](#bands-and-statistics). If no band applies for one input, use an empty array.                                                                                                                                                       |
 | input                   | [Input Structure Object](#input-structure-object)        | **REQUIRED** The N-dimensional array definition that describes the shape, dimension ordering, and data type.                                                                                                                                                                                                                                                                                                             |
@@ -358,16 +361,21 @@ unavailable from [Band Statistics][stac-1.1-stats], such as `value`-specific sca
 (see [Value Scaling Object](#value-scaling-object) for more details).
 
 [stac-1.1-band]: https://github.com/radiantearth/stac-spec/blob/v1.1.0/commons/common-metadata.md#bands
+
 [stac-1.1-stats]: https://github.com/radiantearth/stac-spec/blob/v1.1.0/commons/common-metadata.md#statistics-object
+
 [stac-eo-band]: https://github.com/stac-extensions/eo/tree/v1.1.0#band-object
+
 [stac-raster-band]: https://github.com/stac-extensions/raster/tree/v1.1.0#raster-band-object
+
 [stac-raster-stats]: https://github.com/stac-extensions/raster/tree/v1.1.0#statistics-object
+
 [stac-band-names]: https://github.com/stac-extensions/eo#common-band-names
 
 #### Model Band Object
 
 | Field Name | Type   | Description                                                                                                                            |
-|------------|--------|----------------------------------------------------------------------------------------------------------------------------------------|
+| ---------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------- |
 | name       | string | **REQUIRED** Name of the band referring to an extended band definition (see [Bands](#bands-and-statistics) details).                   |
 | format     | string | The type of expression that is specified in the `expression` property.                                                                 |
 | expression | \*     | An expression compliant with the `format` specified. The expression can be applied to any data type and depends on the `format` given. |
@@ -489,6 +497,7 @@ a `pre_processing_function` should be used instead (see [Model Input Object](#mo
 #### Resize Enum
 
 Select one option from:
+
 - `crop`
 - `pad`
 - `interpolation-nearest`
@@ -516,16 +525,16 @@ Taking inspiration from [Processing Extension - Expression Object][stac-proc-exp
 at the very least a `format` and the applicable `expression` for it to perform pre/post-processing operations on MLM
 inputs/outputs.
 
-| Field Name | Type   | Description |
-| ---------- | ------ | ----------- |
-| format     | string | **REQUIRED** The type of the expression that is specified in the `expression` property. |
+| Field Name | Type   | Description                                                                                                                                                     |
+| ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| format     | string | **REQUIRED** The type of the expression that is specified in the `expression` property.                                                                         |
 | expression | \*     | **REQUIRED** An expression compliant with the `format` specified. The expression can be any data type and depends on the `format` given, e.g. string or object. |
 
 On top of the examples already provided by [Processing Extension - Expression Object][stac-proc-expr],
 the following formats are recommended as alternative scripts and function references.
 
 | Format   | Type   | Description                            | Expression Example                                                                                   |
-|----------|--------|----------------------------------------|------------------------------------------------------------------------------------------------------|
+| -------- | ------ | -------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `python` | string | A Python entry point reference.        | `my_package.my_module:my_processing_function` or `my_package.my_module:MyClass.my_method`            |
 | `docker` | string | An URI with image and tag to a Docker. | `ghcr.io/NAMESPACE/IMAGE_NAME:latest`                                                                |
 | `uri`    | string | An URI to some binary or script.       | `{"href": "https://raw.githubusercontent.com/ORG/REPO/TAG/package/cli.py", "type": "text/x-python"}` |
@@ -547,7 +556,7 @@ the following formats are recommended as alternative scripts and function refere
 ### Model Output Object
 
 | Field Name               | Type                                                    | Description                                                                                                                                                                     |
-|--------------------------|---------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | name                     | string                                                  | **REQUIRED** Name of the output variable defined by the model. If no explicit name is defined by the model, an informative name (e.g.: `"CLASSIFICATION"`) can be used instead. |
 | tasks                    | \[[Task Enum](#task-enum)]                              | **REQUIRED** Specifies the Machine Learning tasks for which the output can be used for. This can be a subset of `mlm:tasks` defined under the Item `properties` as applicable.  |
 | result                   | [Result Structure Object](#result-structure-object)     | **REQUIRED** The structure that describes the resulting output arrays/tensors from one model head.                                                                              |
@@ -599,7 +608,7 @@ Following is an example of what the hyperparameters definition could look like:
 ## Assets Objects
 
 | Field Name      | Type                       | Description                                                                               |
-|-----------------|----------------------------|-------------------------------------------------------------------------------------------|
+| --------------- | -------------------------- | ----------------------------------------------------------------------------------------- |
 | mlm:model       | [Asset Object][stac-asset] | **REQUIRED** Asset object containing the model definition.                                |
 | mlm:source_code | [Asset Object][stac-asset] | **RECOMMENDED** Source code description. Can describe a Git repository, ZIP archive, etc. |
 | mlm:container   | [Asset Object][stac-asset] | **RECOMMENDED** Information to run the model in a container with URI to the container.    |
@@ -642,19 +651,19 @@ the [Model Asset](#model-asset).
 
 In order to provide more context, the following roles are also recommended were applicable:
 
-| Asset Role                | Additional Roles        | Description                                                                              |
-|---------------------------|-------------------------|------------------------------------------------------------------------------------------|
-| mlm:inference-runtime (*) | `runtime`               | Describes an Asset that provides runtime reference to perform model inference.           |
-| mlm:training-runtime (*)  | `runtime`               | Describes an Asset that provides runtime reference to perform model training.            |
-| mlm:checkpoint (*)        | `weights`, `checkpoint` | Describes an Asset that provides a model checkpoint with embedded model configurations.  |
-| mlm:weights               | `weights`, `checkpoint` | Describes an Asset that provides a model weights (typically some Tensor representation). |
-| mlm:model                 | `model`                 | **REQUIRED** Role for [Model Asset](#model-asset).                                       |
-| mlm:source_code           | `code`                  | **RECOMMENDED** Role for [Source Code Asset](#source-code-asset).                        |
+| Asset Role                 | Additional Roles        | Description                                                                              |
+| -------------------------- | ----------------------- | ---------------------------------------------------------------------------------------- |
+| mlm:inference-runtime (\*) | `runtime`               | Describes an Asset that provides runtime reference to perform model inference.           |
+| mlm:training-runtime (\*)  | `runtime`               | Describes an Asset that provides runtime reference to perform model training.            |
+| mlm:checkpoint (\*)        | `weights`, `checkpoint` | Describes an Asset that provides a model checkpoint with embedded model configurations.  |
+| mlm:weights                | `weights`, `checkpoint` | Describes an Asset that provides a model weights (typically some Tensor representation). |
+| mlm:model                  | `model`                 | **REQUIRED** Role for [Model Asset](#model-asset).                                       |
+| mlm:source_code            | `code`                  | **RECOMMENDED** Role for [Source Code Asset](#source-code-asset).                        |
 
 <!-- lint disable no-undefined-references -->
 
 > [!NOTE]
-> (*) These roles are offered as direct conversions from the previous extension
+> (\*) These roles are offered as direct conversions from the previous extension
 > that provided [ML-Model Asset Roles][ml-model-asset-roles] to provide easier upgrade to the MLM extension.
 
 <!-- lint enable no-undefined-references -->
@@ -664,7 +673,7 @@ In order to provide more context, the following roles are also recommended were 
 ### Model Asset
 
 | Field Name         | Type                                                                   | Description                                                                                                                                                                                                                                                                                                               |
-|--------------------|------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------ | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | title              | string                                                                 | Description of the model asset.                                                                                                                                                                                                                                                                                           |
 | href               | string                                                                 | URI to the model artifact.                                                                                                                                                                                                                                                                                                |
 | type               | string                                                                 | The media type of the artifact (see [Model Artifact Media-Type](#model-artifact-media-type).                                                                                                                                                                                                                              |
@@ -707,19 +716,20 @@ See the [Best Practices - Framework Specific Artifact Types](./best-practices.md
  suggested fields for framework specific artifact types.
 
 [iana-media-type]: https://www.iana.org/assignments/media-types/media-types.xhtml
+
 [pytorch-aot-inductor]: https://pytorch.org/docs/main/torch.compiler_aot_inductor.html
 
 #### Compile Method
 
 | Compile Method | Description                                                                                                                                                                                                                                                                                                                                                                               |
-|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | aot            | [Ahead-of-Time Compilation](https://en.wikipedia.org/wiki/Ahead-of-time_compilation). Converts a higher level code description of a model and a model's learned weights to a lower level representation prior to executing the model. This compiled model may be more portable by having fewer runtime dependencies and optimized for specific hardware.                                  |
 | jit            | [Just-in-Time Compilation](https://en.wikipedia.org/wiki/Just-in-time_compilation). Converts a higher level code description of a model and a model's learned weights to a lower level representation while executing the model. JIT provides more flexibility in the optimization approaches that can be applied to a model compared to AOT, but sacrifices portability and performance. |
 
 ### Source Code Asset
 
 | Field Name     | Type      | Description                                                                   |
-|----------------|-----------|-------------------------------------------------------------------------------|
+| -------------- | --------- | ----------------------------------------------------------------------------- |
 | title          | string    | Title of the source code.                                                     |
 | href           | string    | URI to the code repository, a ZIP archive, or an individual code/script file. |
 | type           | string    | Media-type of the URI.                                                        |
@@ -749,17 +759,18 @@ since the source code asset might also refer to more detailed metadata than this
 
 ### Container Asset
 
-| Field Name  | Type      | Description                                                                       |
-|-------------|-----------|-----------------------------------------------------------------------------------|
-| title       | string    | Description of the container.                                                     |
-| href        | string    | URI of the published container, including the container registry, image and tag.  |
-| type        | string    | Media-type of the container, typically `application/vnd.oci.image.index.v1+json`. |
-| roles       | \[string] | Specify `["runtime"]` and any other custom roles.                                 |
+| Field Name | Type      | Description                                                                       |
+| ---------- | --------- | --------------------------------------------------------------------------------- |
+| title      | string    | Description of the container.                                                     |
+| href       | string    | URI of the published container, including the container registry, image and tag.  |
+| type       | string    | Media-type of the container, typically `application/vnd.oci.image.index.v1+json`. |
+| roles      | \[string] | Specify `["runtime"]` and any other custom roles.                                 |
 
 If you're unsure how to containerize your model, we suggest starting from the latest official container image for
 your framework that works with your model and pinning the container version.
 
 Examples:
+
 - [Pytorch Dockerhub](https://hub.docker.com/r/pytorch/pytorch/tags)
 - [Pytorch Docker Run Example](https://github.com/pytorch/pytorch?tab=readme-ov-file#docker-image)
 - [Tensorflow Dockerhub](https://hub.docker.com/r/tensorflow/tensorflow/tags?page=8&ordering=last_updated)
@@ -776,6 +787,7 @@ RUN pip install my_package
 ```
 
 You can also use other base images. Pytorch and Tensorflow offer docker images for serving models for inference.
+
 - [Torchserve](https://pytorch.org/serve/)
 - [TFServing](https://github.com/tensorflow/serving)
 
@@ -786,7 +798,7 @@ The following types should be used as applicable `rel` types in the
 of STAC Items describing Band Assets that result from the inference of a model described by the MLM extension.
 
 | Type         | Description                                              |
-|--------------|----------------------------------------------------------|
+| ------------ | -------------------------------------------------------- |
 | derived_from | This link points to a STAC Collection or Item using MLM. |
 
 It is recommended that the link using `derived_from` referring to another STAC definition using the MLM extension
@@ -805,6 +817,7 @@ For contributions, please follow the
 for running tests are copied here for convenience.
 
 [stac-spec-code-conduct]: https://github.com/radiantearth/stac-spec/blob/master/CODE_OF_CONDUCT.md
+
 [stac-spec-contrib-guide]: https://github.com/radiantearth/stac-spec/blob/master/CONTRIBUTING.md
 
 ### Running tests
@@ -820,6 +833,7 @@ npm install
 ```
 
 Then to check Markdown formatting and test the examples against the JSON schema, you can run:
+
 ```bash
 npm test
 ```
@@ -827,6 +841,7 @@ npm test
 This will spit out the same texts that you see online, and you can then go and fix your markdown or examples.
 
 If the tests reveal formatting problems with the examples, you can fix them with:
+
 ```bash
 npm run format-examples
 ```

--- a/README_DLM_LEGACY.md
+++ b/README_DLM_LEGACY.md
@@ -1,4 +1,4 @@
-# Deep Learning Model (DLM) Extension 
+# Deep Learning Model (DLM) Extension
 
 <!-- lint disable no-undefined-references -->
 

--- a/README_STAC_MODEL.md
+++ b/README_STAC_MODEL.md
@@ -16,7 +16,7 @@
 [![Semantic versions][blic3]][bp5]
 [![Pipelines][bscm6]][bscm7]
 
-_A PydanticV2 and PySTAC validation and serialization library for the STAC ML Model Extension_
+*A PydanticV2 and PySTAC validation and serialization library for the STAC ML Model Extension*
 
 </div>
 
@@ -34,6 +34,7 @@ or install with uv:
 ```shell
 uv add stac-model
 ```
+
 Then you can run
 
 ```shell
@@ -53,44 +54,66 @@ This will make [this example item](./examples/item_basic.json) for an example mo
 You can see the list of available releases on the [GitHub Releases][github-releases] page.
 
 ## 📄 License
+
 [![License][blic1]][blic2]
 
 This project is licenced under the terms of the `Apache Software License 2.0` licence.
 See [LICENSE][blic2] for more details.
 
 ## 💗 Credits
+
 [![Python project templated from galactipy.][bp6]][bp7]
 
 <!-- Anchors -->
 
 [bp1]: https://img.shields.io/pypi/pyversions/stac-model?style=for-the-badge
+
 [bp2]: https://pypi.org/project/stac-model/
+
 [bp3]: https://img.shields.io/pypi/v/stac-model?style=for-the-badge&logo=pypi&color=3775a9
+
 [bp4]: https://github.com/stac-extensions/mlm
+
 [bp5]: https://github.com/stac-extensions/mlm/releases
+
 [bp6]: https://img.shields.io/badge/made%20with-galactipy%20%F0%9F%8C%8C-179287?style=for-the-badge&labelColor=193A3E
+
 [bp7]: https://kutt.it/7fYqQl
+
 [bp8]: https://img.shields.io/static/v1.svg?label=Contributions&message=Welcome&color=0059b3&style=for-the-badge
+
 [bp9]: https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md
+
 [bp11]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json&style=for-the-badge
+
 [bp12]: https://docs.astral.sh/uv/
 
 [bp15]: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white&style=for-the-badge
+
 [bp16]: https://github.com/stac-extensions/mlm/blob/main/.pre-commit-config.yaml
 
 [blic1]: https://img.shields.io/github/license/stac-extensions/mlm?style=for-the-badge
+
 [blic2]: https://github.com/stac-extensions/mlm/blob/main/LICENSE
+
 [blic3]: https://img.shields.io/badge/%F0%9F%93%A6-semantic%20versions-4053D6?style=for-the-badge
 
 [github-releases]: https://github.com/stac-extensions/mlm/releases
 
 [bscm1]: https://img.shields.io/badge/GitHub-100000?style=for-the-badge&logo=github&logoColor=white
+
 [bscm2]: https://img.shields.io/github/v/release/stac-extensions/mlm?filter=stac-model-v*&style=for-the-badge&logo=semantic-release&color=347d39
+
 [bscm6]: https://img.shields.io/github/actions/workflow/status/stac-extensions/mlm/publish.yaml?style=for-the-badge&logo=github
+
 [bscm7]: https://github.com/stac-extensions/mlm/blob/main/.github/workflows/publish.yaml
 
 [hub1]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates
+
 [hub2]: https://github.com/marketplace/actions/close-stale-issues
+
 [hub6]: https://docs.github.com/en/code-security/dependabot
+
 [hub8]: https://github.com/stac-extensions/mlm/blob/main/.github/release-drafter.yml
+
 [hub9]: https://github.com/stac-extensions/mlm/blob/main/.github/.stale.yml

--- a/best-practices.md
+++ b/best-practices.md
@@ -35,6 +35,7 @@ it is left to the good judgement of users to provide adequate values. Note that 
 choose to apply it for contexts outside the *recommended* extent for the same reason.
 
 [EuroSAT-github]: https://github.com/phelber/EuroSAT
+
 [EuroSAT-paper]: https://www.researchgate.net/publication/319463676
 
 As another example, let us consider a model which is trained on imagery from all over the world
@@ -102,6 +103,7 @@ should be specified with a reference to the STAC Item employing the MLM extensio
 of the derived product.
 
 A potential representation of a STAC Asset could be as follows:
+
 ```json
 {
   "model-output": {
@@ -302,7 +304,7 @@ framework-specific definitions to help the users understand how the model artifa
 names are not strictly required either.
 
 | Artifact Type                      | Description                                                                                                                                                                                                                                                                                                                                   |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `torch.save`                       | A [serialized python pickle object][pytorch-save] (i.e.: `.pt`) which can represent a model or state_dict.                                                                                                                                                                                                                                    |
 | `torch.jit.save`                   | A [`TorchScript`][pytorch-jit-script] model artifact obtained with one or more of the graph export options TorchScript Tracing and Scripting.                                                                                                                                                                                                 |
 | `torch.export.save`                | A model artifact storing an [ExportedProgram][exported-program] obtained by [`torch.export.export`][pytorch-export] (i.e.: `.pt2`).                                                                                                                                                                                                           |
@@ -312,17 +314,31 @@ names are not strictly required either.
 | `safetensors.{framework}.{method}` | Model weights saved as [HuggingFace SafeTensors][hf-st], where `{framework}` matches the [`mlm:framework`][mlm-framework] of a [*supported framework*][hf-st-support] and `{method}` matches the applicable method from SafeTensors. For example, a PyTorch model saved this way would indicate [`safetensors.torch.save_file`][hf-st-torch]. |
 
 [exported-program]: https://pytorch.org/docs/main/export.html#serialization
+
 [pytorch-aot-inductor]: https://pytorch.org/docs/main/torch.compiler_aot_inductor.html
+
 [pytorch-export]: https://pytorch.org/docs/main/export.html
+
 [pytorch-frameworks]: https://pytorch.org/docs/main/export.html#existing-frameworks
+
 [pytorch-jit-script]: https://pytorch.org/docs/stable/jit.html
+
 [pytorch-save]: https://pytorch.org/tutorials/beginner/saving_loading_models.html
+
 [keras-save-weights]: https://keras.io/api/models/model_saving_apis/weights_saving_and_loading/#save_weights-method
+
 [tf-saved-model]: https://keras.io/api/models/model_saving_apis/export/
+
 [tf-keras-recommended]: https://www.tensorflow.org/guide/saved_model#creating_a_savedmodel_from_keras
+
 [keras-methods]: https://keras.io/2.16/api/models/model_saving_apis/
+
 [keras-model]: https://keras.io/api/models/model_saving_apis/model_saving_and_loading/
+
 [hf-st]: https://github.com/huggingface/safetensors
+
 [hf-st-support]: https://huggingface.co/docs/safetensors/index#featured-projects
+
 [hf-st-torch]: https://huggingface.co/docs/safetensors/api/torch#safetensors.torch.save_file
+
 [mlm-framework]: README.md#item-properties-and-collection-fields

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   },
   "dependencies": {
     "remark-cli": "^8.0.0",
+    "remark-gfm": "^4.0.0",
     "remark-lint": "^7.0.0",
     "remark-lint-no-html": "^2.0.0",
-    "remark-gfm": "^4.0.0",
+    "remark-math": "^6.0.0",
     "remark-preset-lint-consistent": "^3.0.0",
     "remark-preset-lint-markdown-style-guide": "^3.0.0",
     "remark-preset-lint-recommended": "^4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,18 +163,23 @@ replace = """
 ## [Unreleased](https://github.com/stac-extensions/mlm/tree/main)
 
 ### Added
+
 - n/a
 
 ### Changed
+
 - n/a
 
 ### Deprecated
+
 - n/a
 
 ### Removed
+
 - n/a
 
 ### Fixed
+
 - n/a
 
 ## [v{new_version}](https://github.com/stac-extensions/mlm/tree/v{new_version})


### PR DESCRIPTION
## Description

~*Mostly*~ Fixes the auto formatting of markdown files.

~Still some weird escape behavior in math expressions that I have not figured out (ie: `\min`, `\max` and `\times` are incorrectly escaped with  `\\`).  Investigating...~
fix using ``` $` \min ... `$ ``` to encapsulate the equations and parse them as intented

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] :books: Examples, docs, tutorials or dependencies update;
- [x] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md) guide;
- [x] I've updated the code style using `make check`;
- [x] I've written tests for all new methods and classes that I created;
- [x] I've written the docstring in `Google` format for all the methods and classes that I used.
