### PR TITLE
add `embedding` as suggested dimension order name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `embedding` as suggested dimension name
+  (relates to [#77](https://github.com/stac-extensions/mlm/discussions/77)).
 - Add [`huggingface/safetensors`](https://github.com/huggingface/safetensors)
   recommendations for `mlm:artifact_type` and corresponding `mlm:framework` values
   (fixes [#68](https://github.com/stac-extensions/mlm/issues/68)).

--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ Below are some notable common names recommended for use, but others can be emplo
 - `class`
 - `score`
 - `confidence`
+- `embedding`
 
 For example, a tensor of multiple RBG images represented as $`B \times C \times H \times W`$ should
 indicate `dim_order = ["batch", "channel", "height", "width"]`.

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -747,7 +747,8 @@
           "token",
           "class",
           "score",
-          "confidence"
+          "confidence",
+          "embedding"
         ]
       }
     },


### PR DESCRIPTION
## Description

As requested by the community, provides `embedding` as suggested `dim_order` value. 

This is non-breaking, since the names are not explicitly enforced (not `enum` values). It is only informative.

## Related Issue

-  https://github.com/stac-extensions/mlm/discussions/77

## Type of Change

- [x] :books: Examples, docs, tutorials or dependencies update;
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md) guide;
- [x] I've updated the code style using `make check`;
- [x] I've written tests for all new methods and classes that I created;
- [x] I've written the docstring in `Google` format for all the methods and classes that I used.
