### PR TITLE
improve resources references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ connectors, please refer to the [STAC Model](./README_STAC_MODEL.md) document.
   - [`stac-model`](./stac_model): Model implementations using [`Pydantic`](https://docs.pydantic.dev/latest/).
     See the [STAC Model](./README_STAC_MODEL.md) document for installation and example details.
   - [`pystac.extensions.mlm`](https://github.com/stac-utils/pystac/blob/main/pystac/extensions/mlm.py): 
-    Official [`pystac`](https://github.com/stac-utils/pystac) extension integration
-    (avaiable starting with [`pystac v1.13.0`](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md#v1130)).
+    Official [`pystac`](https://github.com/stac-utils/pystac) extension integration (avaiable starting
+    with [`pystac v1.13.0`](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md#v1130---2025-04-15)).
 - **Examples**:
   - [Local Examples](./examples): Demonstrates different combinations of STAC extensions used along MLM.
   - [Item examples](https://huggingface.co/wherobots/mlm-stac): Demonstrates `scene-classification`,

--- a/README.md
+++ b/README.md
@@ -94,19 +94,31 @@ connectors, please refer to the [STAC Model](./README_STAC_MODEL.md) document.
 
 ## Resources
 
-- Examples:
-  - [Item examples](https://huggingface.co/wherobots/mlm-stac) for scene-classification,
-      object detection, and semantic segmentation: Shows real world use of the
-      extension for describing models run on
-      [WherobotsAI Raster Inference](https://wherobots.com/wherobotsai-for-raster-inference/)
-  - [Collection example](examples/collection.json): Shows the basic usage of the extension in a STAC Collection
-- [JSON Schema](https://stac-extensions.github.io/mlm/)
-- [Changelog](./CHANGELOG.md)
-- [Open access paper](https://dl.acm.org/doi/10.1145/3681769.3698586) describing version 1.3.0 of the extension
-- [SigSpatial 2024 GeoSearch Workshop presentation](/docs/static/sigspatial_2024_mlm.pdf)
-- [MLM Form Filler](https://mlm-form.vercel.app/) a two page app to fill out and validate MLM STAC Item metadata. <br>
-  Check out the [wherobots/mlm-form](https://github.com/wherobots/mlm-form) repository if you have questions, issues,
-  or want to contribute.
+- **Packages**:
+  - [`stac-model`](./stac_model): Model implementations using [`Pydantic`](https://docs.pydantic.dev/latest/).
+    See the [STAC Model](./README_STAC_MODEL.md) document for installation and example details.
+  - [`pystac.extensions.mlm`](https://github.com/stac-utils/pystac/blob/main/pystac/extensions/mlm.py): 
+    Official [`pystac`](https://github.com/stac-utils/pystac) extension integration
+    (avaiable starting with [`pystac v1.13.0`](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md#v1130)).
+- **Examples**:
+  - [Local Examples](./examples): Demonstrates different combinations of STAC extensions used along MLM.
+  - [Item examples](https://huggingface.co/wherobots/mlm-stac): Demonstrates `scene-classification`,
+      `object-detection`, and `semantic-segmentation` tasks with real world use of the
+      MLM extension for describing models run on
+      [WherobotsAI Raster Inference](https://wherobots.com/wherobotsai-for-raster-inference/).
+  - [Collection example](examples/collection.json): Shows the basic usage of the extension in a STAC Collection.
+- **Documentation**:
+  - [JSON Schema](https://stac-extensions.github.io/mlm/)
+  - [Changelog](./CHANGELOG.md)
+  - [Best Practices](./best-practices.md): Recommended combinations of MLM with
+    other [STAC Extensions](https://stac-extensions.github.io/) for efficient integration into the STAC ecosystem.
+  - [Open access paper](https://dl.acm.org/doi/10.1145/3681769.3698586) describing
+    version [`1.3.0`](https://github.com/stac-extensions/mlm/blob/main/CHANGELOG.md#v130) of the extension.
+  - [SigSpatial 2024 GeoSearch Workshop presentation](/docs/static/sigspatial_2024_mlm.pdf)
+- **Tools**:
+  - [MLM Form Filler](https://mlm-form.vercel.app/) a two page app to fill out and validate MLM STAC Item metadata. <br>
+    Check out the [wherobots/mlm-form](https://github.com/wherobots/mlm-form) repository if you have questions, issues,
+    or want to contribute.
 
 ## Item Properties and Collection Fields
 


### PR DESCRIPTION

## Description

- Add `pystac.extensions.mlm` reference (relates to https://github.com/stac-utils/pystac/pull/1542)
- Update listing of resources with more details and formatting

> [!NOTE]
> Reference to "`pystac v1.13.0`" is defined. This is not yet released, but expected to be the next version. 
> Waiting on this to be released to validate and merge...

## Related Issue

- https://github.com/stac-utils/pystac/pull/1542

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] :books: Examples, docs, tutorials or dependencies update;
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md) guide;
- [x] I've updated the code style using `make check`;
- [x] I've written tests for all new methods and classes that I created;
- [x] I've written the docstring in `Google` format for all the methods and classes that I used.
