### PR TITLE
initial export and load logic for PT2 archives

### DIFF
--- a/stac_model/schema.py
+++ b/stac_model/schema.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from collections.abc import Iterable
 from typing import (
     Annotated,
@@ -25,6 +26,31 @@ from stac_model.base import ModelTask, OmitIfNone
 from stac_model.input import ModelInput
 from stac_model.output import ModelOutput
 from stac_model.runtime import Runtime
+import zipfile
+
+# Optional imports for ML frameworks
+try:
+    import torch
+except ImportError:
+    torch = None
+
+try:
+    import tensorflow as tf
+except ImportError:
+    tf = None
+
+try:
+    import sklearn
+    import joblib
+except ImportError:
+    sklearn = None
+    joblib = None
+
+try:
+    import onnx
+except ImportError:
+    onnx = None
+
 
 T = TypeVar(
     "T",
@@ -53,6 +79,11 @@ class MLModelProperties(Runtime):
     pretrained: Annotated[bool | None, OmitIfNone] = Field(default=True)
     pretrained_source: Annotated[str | None, OmitIfNone] = None
 
+    # Add framework and artifact_type if not already present from Runtime
+    framework: Annotated[str | None, OmitIfNone] = None
+    framework_version: Annotated[str | None, OmitIfNone] = None
+    artifact_type: Annotated[str | None, OmitIfNone] = None # Added for consistency
+
     model_config = ConfigDict(alias_generator=mlm_prefix_adder, populate_by_name=True, extra="ignore")
 
 
@@ -71,6 +102,202 @@ class MLModelExtension(
         ]
     ],
 ):
+    @classmethod
+    def export_model(
+        cls,
+        model: Any,
+        properties: MLModelProperties,
+        output_path: Union[str, Path],
+    ) -> tuple[str, str]:
+        """
+        Saves a model and its MLM properties to a specified path, returning
+        the determined framework and artifact type.
+
+        This method attempts to package the model artifact and its
+        MLModelProperties (serialized as JSON) together. The saving
+        strategy depends on the model's framework.
+
+        Args:
+            model: The machine learning model instance (PyTorch, TF/Keras, scikit-learn, ONNX).
+            properties: The MLModelProperties describing the model.
+            output_path: The file or directory path to save the packaged model and metadata.
+
+        Returns:
+            A tuple containing the determined framework (str) and artifact_type (str).
+
+        Raises:
+            ImportError: If the required ML framework library is not installed.
+            TypeError: If the model type is not supported.
+            Exception: For framework-specific saving errors.
+        """
+        output_path = Path(output_path)
+        mlm_data = properties.model_dump_json(by_alias=True, indent=2)
+        # Use framework from properties if provided, otherwise try to detect
+        framework = properties.framework.lower() if properties.framework else None
+        artifact_type = None
+        detected_framework = None # Store detected framework separately
+
+        # --- PyTorch ---
+        if torch and isinstance(model, torch.nn.Module):
+            detected_framework = "pytorch"
+            if not framework:
+                framework = detected_framework
+            if framework != detected_framework:
+                 raise ValueError(
+                     f"Framework '{framework}' specified in MLModelProperties does not match detected framework '{detected_framework} of the model'."
+                 )
+            try:
+                # ExportedProgram with all operators so the nn.Module can be accessed on load
+                # https://pytorch.org/tutorials/intermediate/torch_export_tutorial.html
+                example_input = torch.randn(1, 3, 256, 256) # TODO get this from MLM properties
+                ep_for_training = torch.export.export_for_training(model, (example_input,))
+                torch.export.save(ep_for_training, output_path, extra_files={"mlm_properties": mlm_data})
+                artifact_type = "torch.save"
+                print(f"PyTorch model and MLM metadata saved to: {output_path}")
+            except Exception as e:
+                print(f"Error saving PyTorch model: {e}")
+                raise
+
+        else:
+            supported_frameworks = []
+            if torch:
+                supported_frameworks.append("PyTorch")
+            if tf:
+                supported_frameworks.append("TensorFlow/Keras")
+            if sklearn:
+                supported_frameworks.append("Scikit-learn")
+            if onnx:
+                supported_frameworks.append("ONNX")
+            raise TypeError(
+                f"Unsupported model type: {type(model)}. "
+                f"Supported frameworks with detected libraries: {', '.join(supported_frameworks)}"
+            )
+
+        return framework, artifact_type
+
+    def load_model(self) -> Any:
+        """
+        Loads a model's framework representation from the MLM definition
+        stored in the associated STAC object (Item/Asset).
+
+        This method finds the asset with the 'mlm:model' role, reads its
+        href and mlm:artifact_type, and attempts to load the model artifact.
+        It may also load MLM properties if they are packaged with the model.
+
+        Returns:
+            The loaded model object (framework-specific).
+
+        Raises:
+            ValueError: If the model asset or required properties are missing.
+            ImportError: If the required ML framework library is not installed.
+            FileNotFoundError: If the model artifact href cannot be found.
+            Exception: For framework-specific loading errors.
+        """
+        model_asset = None
+        asset_href = None
+        artifact_type = None
+        mlm_props_dict = None # To store properties loaded from archive
+
+        # Find the STAC object this extension is attached to
+        stac_object = getattr(self, 'item', getattr(self, 'asset', getattr(self, 'collection', None)))
+        if not stac_object:
+             raise ValueError("MLModelExtension is not attached to a valid STAC object (Item, Asset, Collection).")
+
+        # Find the asset dictionary
+        assets_dict = None
+        if hasattr(stac_object, 'assets'):
+            assets_dict = stac_object.assets
+        elif isinstance(stac_object, pystac.Asset): # If the extension is directly on an Asset
+             # We need the owner (Item/Collection) to get the full context potentially
+             owner = getattr(stac_object, 'owner', None)
+             if owner and hasattr(owner, 'assets'):
+                  # Find the asset key within the owner's assets
+                  for key, asset_obj in owner.assets.items():
+                       if asset_obj == stac_object:
+                            model_asset = asset_obj # Found it
+                            asset_href = model_asset.href
+                            break
+                  if not model_asset:
+                       print("Warning: Extension is on an Asset, but couldn't find it in owner's assets.")
+                       # Fallback: treat the asset's own fields
+                       model_asset = stac_object
+                       asset_href = model_asset.href
+             else: # Asset has no owner or owner has no assets dict
+                  model_asset = stac_object
+                  asset_href = model_asset.href
+        else:
+             raise ValueError("Cannot find assets in the STAC object.")
+
+        # Find the specific asset with the 'mlm:model' role if not already identified
+        if not model_asset and assets_dict:
+            for asset in assets_dict.values():
+                # pystac Assets have .extra_fields for roles, not direct attribute
+                if 'mlm:model' in asset.extra_fields.get('roles', []):
+                    model_asset = asset
+                    asset_href = model_asset.href
+                    break
+
+        if not model_asset:
+            raise ValueError("Could not find an asset with the 'mlm:model' role.")
+
+        if not asset_href:
+            raise ValueError("Model asset found, but it does not have an 'href'.")
+
+        # Get artifact type from the asset itself
+        # pystac Assets store extension fields in .extra_fields
+        artifact_type = model_asset.extra_fields.get('mlm:artifact_type')
+
+        if not artifact_type:
+             raise ValueError("Model asset must have the 'mlm:artifact_type' property defined in its extra_fields.")
+
+        # Resolve the model path (handle relative paths)
+        try:
+            model_path = Path(pystac.utils.make_absolute_href(asset_href, start_href=stac_object.get_self_href(), start_is_dir=False))
+            if not model_path.exists():
+                 # Check if it's a directory path that might exist
+                 if not (model_path.is_dir() and artifact_type == "tf.keras.Model.export"):
+                      raise FileNotFoundError
+        except Exception:
+             raise FileNotFoundError(f"Model artifact not found or inaccessible at resolved href: {asset_href}")
+
+
+        # --- Load based on artifact_type ---
+        loaded_model = None
+
+        # PyTorch (.pt file with state_dict and potentially mlm_properties)
+        if artifact_type == "torch.save":
+            if not torch:
+                raise ImportError("PyTorch is required to load this model artifact, but it is not installed.")
+            try:
+                # Load using torch.export.load for ExportedProgram
+                # https://pytorch.org/docs/stable/export.html#torch.export.load
+                ep = torch.export.load(model_path)
+                loaded_model = ep.module() # Access the original nn.Module
+
+                # Attempt to load extra files (MLM properties) if they exist
+                # Note: torch.export.load doesn't directly expose extra_files like torch.load
+                # We might need to rely on the user accessing them separately if needed,
+                # or consider if they should be part of the STAC metadata instead.
+                # For now, we assume the essential model is loaded.
+                # If mlm_properties were saved, they are inside the file but not directly accessible via torch.export.load API.
+
+                print(f"PyTorch model loaded from: {model_path}")
+
+            except Exception as e:
+                print(f"Error loading PyTorch model from {model_path}: {e}")
+                raise
+        else:
+            raise ValueError(f"Unsupported 'mlm:artifact_type' for loading: {artifact_type}")
+
+        if not loaded_model:
+             raise RuntimeError(f"Model loading failed for artifact type '{artifact_type}' from {model_path}")
+
+        # Optionally attach loaded properties to the model (if we could load them)
+        # if mlm_props_dict:
+        #      setattr(loaded_model, '_mlm_properties', mlm_props_dict)
+
+        return loaded_model
+
     @property
     def name(self) -> SchemaName:
         return cast(SchemaName, get_args(SchemaName)[0])
@@ -83,8 +310,15 @@ class MLModelExtension(
         Applies Machine Learning Model Extension properties to the extended :mod:`~pystac` object.
         """
         if isinstance(properties, dict):
-            properties = MLModelProperties(**properties)
-        data_json = json.loads(properties.model_dump_json(by_alias=True))
+            # Ensure framework and artifact_type are handled if present
+            properties_obj = MLModelProperties(**properties)
+        elif isinstance(properties, MLModelProperties):
+             properties_obj = properties
+        else:
+             raise TypeError("properties must be MLModelProperties or dict")
+
+        # Use model_dump to include potential aliases
+        data_json = json.loads(properties_obj.model_dump_json(by_alias=True, exclude_none=True))
         for prop, val in data_json.items():
             self._set_property(prop, val)
 


### PR DESCRIPTION
## Description

This is a WIP PR to implement export and loading of a PT2 model archive containing MLM metadata and optionally containing transforms that can be exported with Pytorch and loaded back to run on CPU or GPU prior to model inference.

It will use [a new pt2 export API](https://github.com/pytorch/pytorch/pull/152495) that will be available in a future release of Pytorch for exporting one or more models with (optional) compiled AOTI model artifacts and model metadata files (MLM).

```
package_pt2(
    f: FileLike,
    *,
    exported_programs: Optional[Union[ExportedProgram, dict[str, ExportedProgram]]] = None,
    aoti_files: Optional[Union[list[str], dict[str, list[str]]]] = None,
    extra_files: Optional[dict[str, Any]] = None,
) -> FileLike

@dataclass
class PT2ArchiveContents:
    exported_programs: dict[str, ExportedProgram]
    aoti_runners: dict[str, AOTICompiledModel]
    extra_files: dict[str, Any]
```

This will help standardize how to store multiple models and model metadatas in a PT2 archive, which we can then generalize to other framework archive types.

Initially I'm thinking that our opinionated STAC MLM + PT2 archive spec would require/suggest

* one primary model file per pt2 archive, referred to by the model_name in the MLM metadata
* optionally one transform model file per pt2 archive, referred to by a processing expression with a new format: `pt2-transform`

So in our instance of a PT2 Archive for a `eurosat_model`, the PT2ArchiveContents would be

```
exported_programs: {'eurosat_model': ExportedProgram,
                                  'transforms': ExportedProgram}
aoti_runners: {'eurosat_model': AOTICompiledModel,
                       'transforms': AOTICompiledModel}
extra_files: {'mlm': mlm.json} # mlm.json refers to eurosat_model and has a ProcessingExpression referring to `transforms`
```


I'm still working out an example where we use TorchGeo to collate and export the mlm metadata tot his archive.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :books: Examples, docs, tutorials or dependencies update;
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md) guide;
- [ ] I've updated the code style using `make check`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
