### PR TITLE
Data cube variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refactor the JSON schema to check for `bands` and `variables` references within both `mlm:input` and `mlm:output`.
+  If either location detects that either `bands` or `variables` is provided, their corresponding sets of extensions
+  providing relevant descriptions are verified.
 - Refactor the JSON schema `mlm:output` property to employ a `ModelOutput` object definition
   rather than directly provided properties nested under the array.
 - Refactor the JSON schema to allow the omission of `bands` under `mlm:input` if the `variables` property is provided.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `variables` properties to [Model Input Object](README.md#model-input-object)
+  to allow specifying the relevant data variables used by the model,
+  with cross-references to the [datacube](https://github.com/stac-extensions/datacube) extension
+  (relates to [#90](https://github.com/stac-extensions/mlm/issues/90)).
+- Add `bands` and `variables` properties to [Model Output Object](README.md#model-output-object)
+  to allow specifying the relevant bands or variables produced by the model if any applies.
+- Add `downscaling` to [Tasks](./README.md#task-enum) as common operation for climate variable models.
 - Add [ML-Model Legacy](./docs/legacy/ml-model.md) document providing migration guidance
   from the deprecated [ML-Model](https://github.com/stac-extensions/ml-model) extension
   (relates to [stac-extensions/ml-model#16](https://github.com/stac-extensions/ml-model/pull/16)).
@@ -25,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refactor the JSON schema `mlm:output` property to employ a `ModelOutput` object definition
+  rather than directly provided properties nested under the array.
+- Refactor the JSON schema to allow the omission of `bands` under `mlm:input` if the `variables` property is provided.
 - Update `stac-model==0.3.0` to provide `ValueScalingObject` from installed package.
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- n/a
+- Fix missing ``encoding="utf-8"`` parameters in `open` calls leading to failing parsing of example JSON STAC Item
+  when they contain non-ASCII characters.
 
 ## [v1.4.0](https://github.com/stac-extensions/mlm/tree/v1.4.0)
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ ifneq ($(findstring $(PYTHON_PATH),bin/python),)
 else
 	PYTHON_ROOT := $(shell dirname $(PYTHON_PATH))
 endif
-$(info ${PYTHON_ROOT} is the Python root directory)
 UV_PYTHON_ROOT ?= $(PYTHON_ROOT)
 
 # to actually reuse an existing virtual/conda environment, the 'UV_PROJECT_ENVIRONMENT' variable must be set to it

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,13 @@ SHELL ?= /usr/bin/env bash
 
 # use the directory rather than the python binary to allow auto-discovery, which is more cross-platform compatible
 PYTHON_PATH := $(shell which python)
-PYTHON_ROOT := $(shell dirname $(dir $(PYTHON_PATH)))
+# handle whether running on Windows or Unix-like systems
+ifneq ($(findstring $(PYTHON_PATH),bin/python),)
+	PYTHON_ROOT := $(shell dirname $(dir $(PYTHON_PATH)))
+else
+	PYTHON_ROOT := $(shell dirname $(PYTHON_PATH))
+endif
+$(info ${PYTHON_ROOT} is the Python root directory)
 UV_PYTHON_ROOT ?= $(PYTHON_ROOT)
 
 # to actually reuse an existing virtual/conda environment, the 'UV_PROJECT_ENVIRONMENT' variable must be set to it
@@ -54,7 +60,7 @@ format: codestyle
 #* Linting
 .PHONY: test
 test: setup
-	$(UV_COMMAND) run --python "$(UV_PYTHON_ROOT)" pytest -c pyproject.toml --cov-report=html --cov=stac_model tests/
+	$(UV_COMMAND) run --python "$(UV_PYTHON_ROOT)" pytest -c pyproject.toml -v --cov-report=html --cov=stac_model tests/
 
 .PHONY: check
 check: check-examples check-markdown check-lint check-mypy check-safety check-citation

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ definitions listed in [Papers With Code](https://paperswithcode.com/sota). The n
 should be normalized to lowercase and use hyphens instead of spaces.
 
 | Task Name               | Corresponding `label:tasks` | Description                                                                                                              |
-| ----------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+|-------------------------| --------------------------- |--------------------------------------------------------------------------------------------------------------------------|
 | `regression`            | `regression`                | Generic regression that estimates a numeric and continuous value.                                                        |
 | `classification`        | `classification`            | Generic classification task that assigns class labels to an output.                                                      |
 | `scene-classification`  | *n/a*                       | Specific classification task where the model assigns a single class label to an entire scene/area.                       |
@@ -224,13 +224,14 @@ should be normalized to lowercase and use hyphens instead of spaces.
 | `generative`            | *n/a*                       | Generic task that encompasses all synthetic data generation techniques.                                                  |
 | `image-captioning`      | *n/a*                       | Specific task of describing the content of an image in words.                                                            |
 | `super-resolution`      | *n/a*                       | Specific task that increases the quality and resolution of an image by increasing its high-frequency details.            |
+| `downscaling`           | *n/a*                       | Specific task reduces the coarser data variables at larger scale to a smaller and finer scale of higher resolution.      |
 
 If the task falls within the category of supervised machine learning and uses labels during training,
 this should align with the `label:tasks` values defined in [STAC Label Extension][stac-ext-label-props] for relevant
 STAC Collections and Items published with the model described by this extension.
 
 It is to be noted that multiple "*generic*" tasks names (`classification`, `detection`, etc.) are defined to allow
-correspondance with `label:tasks`, but these can lead to some ambiguity depending on context. For example, a model
+correspondence with `label:tasks`, but these can lead to some ambiguity depending on context. For example, a model
 that supports `classification` could mean that the model can predict patch-based classes over an entire scene
 (i.e.: `scene-classification` for a single prediction over an entire area of interest as a whole),
 or that it can predict pixel-wise "classifications", such as land-cover labels for

--- a/best-practices.md
+++ b/best-practices.md
@@ -6,19 +6,19 @@ of your model and make life easier for client tooling and users. They come about
 implementors and introduce a bit more 'constraint' for those who are creating STAC objects representing their
 models or creating tools to work with STAC.
 
-- [ML Model Extension Best Practices](#ml-model-extension-best-practices)
-  - [Using STAC Common Metadata Fields for the ML Model Extension](#using-stac-common-metadata-fields-for-the-ml-model-extension)
-  - [Recommended Extensions to Compose with the ML Model Extension](#recommended-extensions-to-compose-with-the-ml-model-extension)
-    - [Processing Extension](#processing-extension)
-    - [ML-AOI and Label Extensions](#ml-aoi-and-label-extensions)
-    - [Classification Extension](#classification-extension)
-    - [Scientific Extension](#scientific-extension)
-    - [File Extension](#file-extension)
-    - [Example Extension](#example-extension)
-    - [Version Extension](#version-extension)
-  - [Framework Specific Artifact Types](#framework-specific-artifact-types)
+- [Using STAC Common Metadata Fields for the MLM Extension](#using-stac-common-metadata-fields-for-the-mlm-extension)
+- [Recommended Extensions to Compose with the MLM Extension](#recommended-extensions-to-compose-with-the-ml-model-extension)
+  - [STAC Bands, EO, Raster and DataCube Extensions](#stac-bands-eo-raster-and-datacube-extensions)
+  - [Processing Extension](#processing-extension)
+  - [ML-AOI and Label Extensions](#ml-aoi-and-label-extensions)
+  - [Classification Extension](#classification-extension)
+  - [Scientific Extension](#scientific-extension)
+  - [File Extension](#file-extension)
+  - [Example Extension](#example-extension)
+  - [Version Extension](#version-extension)
+- [Framework Specific Artifact Types](#framework-specific-artifact-types)
 
-## Using STAC Common Metadata Fields for the ML Model Extension
+## Using STAC Common Metadata Fields for the MLM Extension
 
 It is recommended to use the `start_datetime` and `end_datetime`, `geometry`, and `bbox` in a STAC Item,
 and the corresponding
@@ -67,7 +67,26 @@ If specific datasets with training/validation/test splits are known to support t
 the model, it is recommended that they are included as reference to the STAC Item/Collection using MLM. For more
 information regarding these references, see the [ML-AOI and Label Extensions](#ml-aoi-and-label-extensions) details.
 
-## Recommended Extensions to Compose with the ML Model Extension
+## Recommended Extensions to Compose with the MLM Extension
+
+### STAC Bands, EO, Raster and DataCube Extensions
+
+When a model takes as input or produces as output raster bands, spatio-temporal data variables or leverages 
+Earth Observation data, it is **STRONGLY RECOMMENDED** to use a corresponding STAC Core or Extension specification
+to describe them. This ensures that common metadata fields can be used both for search and retrieval of available
+data provided by catalogues, as well as for models using or producing them.
+
+Relevant extensions include:
+
+- [STAC Common Metadata Bands][]
+
+For further details on how to use thse extensions in the context of the Machine Learning Model extension,
+please refer to the corresponding sections:
+
+- [Model Input Object](./README.md#model-input-object)
+- [Model Output Object](./README.md#model-output-object)
+- [Bands and Statistics](./README.md#bands-and-statistics)
+- [Data Variables](./README.md#data-variables)
 
 ### Processing Extension
 

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -57,6 +57,10 @@
       "rel": "item"
     },
     {
+      "href": "item_datacube_variables.json",
+      "rel": "item"
+    },
+    {
       "href": "item_eo_bands.json",
       "rel": "item"
     },

--- a/examples/item_datacube_variables.json
+++ b/examples/item_datacube_variables.json
@@ -1,0 +1,160 @@
+{
+  "$comment": "Demonstrate the use of MLM and EO for bands description, with EO bands directly in the Model Asset.",
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/mlm/v1.4.0/schema.json",
+    "https://stac-extensions.github.io/datacube/v2.3.0/schema.json",
+    "https://stac-extensions.github.io/ml-aoi/v0.2.0/schema.json",
+    "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
+  ],
+  "type": "Feature",
+  "id": "UNet_ClimateDiffuse_Regression",
+  "collection": "ml-model-examples",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -7.882190080512502,
+          37.13739173208318
+        ],
+        [
+          -7.882190080512502,
+          58.21798141355221
+        ],
+        [
+          27.911651652899923,
+          58.21798141355221
+        ],
+        [
+          27.911651652899923,
+          37.13739173208318
+        ],
+        [
+          -7.882190080512502,
+          37.13739173208318
+        ]
+      ]
+    ]
+  },
+  "bbox": [
+    -7.882190080512502,
+    37.13739173208318,
+    27.911651652899923,
+    58.21798141355221
+  ],
+  "properties": {
+    "description": "UNet model for regression tasks of climate indices of SSP2-4.5 scenario using CMIP6 dataset.",
+    "datetime": null,
+    "start_datetime": "1900-01-01T00:00:00Z",
+    "end_datetime": "2100-12-31T23:59:59Z",
+    "mlm:name": "UNet ClimateDiffuse Regression",
+    "mlm:tasks": [
+      "regression"
+    ],
+    "mlm:architecture": "U-Net",
+    "mlm:framework": "torchgeo",
+    "mlm:framework_version": "0.8.0.dev0",
+    "mlm:accelerator": "cuda",
+    "mlm:accelerator_constrained": false,
+    "mlm:accelerator_summary": "Unknown",
+    "mlm:input": [
+      {
+        "name": "Climate Variables employed by the model for regression.",
+        "variables": [
+          "air_temperature",
+          "soil_moisture_content",
+          "surface_temperature",
+          "surface_air_pressure"
+        ],
+        "input": {
+          "shape": [
+            -1,
+            4,
+            256,
+            256
+          ],
+          "dim_order": [
+            "batch",
+            "variables",
+            "height",
+            "width"
+          ],
+          "data_type": "float32"
+        },
+        "norm_by_channel": false,
+        "resize_type": null
+      }
+    ],
+    "mlm:output": [
+      {
+        "name": "forecast",
+        "tasks": [
+          "regression"
+        ],
+        "result": {
+          "shape": [
+            -1,
+            256,
+            256
+          ],
+          "dim_order": [
+            "precipitation_flux",
+            "class"
+          ],
+          "data_type": "float32"
+        }
+      }
+    ]
+  },
+  "$comment": "Following 'cube:variables' is required to fulfil schema validation. Each 'name' refers to variables used in 'mlm:input' and 'mlm:output'.",
+  "cube:variables": [
+  ],
+  "sci:publications": [
+    {
+      "doi": "10.48550/arXiv.2404.17752",
+      "citation": "Robbie A. Watt, Laura A. Mansfield, Generative Diffusion-based Downscaling for Climate"
+    }
+  ],
+  "assets": {
+    "weights": {
+      "href": "https://huggingface.co/torchgeo/resnet18_sentinel2_all_moco/resolve/main/resnet18_sentinel2_all_moco-59bfdff9.pth",
+      "title": "Pytorch weights checkpoint",
+      "description": "A Resnet-18 classification model trained on normalized Sentinel-2 imagery with Eurosat landcover labels with torchgeo",
+      "type": "application/octet-stream; application=pytorch",
+      "roles": [
+        "mlm:model",
+        "mlm:weights"
+      ],
+      "mlm:artifact_type": "torch.save"
+    },
+    "source_code": {
+      "href": "https://raw.githubusercontent.com/robbiewatt1/ClimateDiffuse/refs/heads/main/src/Network.py",
+      "title": "Model implementation.",
+      "description": "Source code to run the model.",
+      "type": "text/x-python",
+      "roles": [
+        "mlm:source_code",
+        "code",
+        "metadata"
+      ]
+    }
+  },
+  "links": [
+    {
+      "rel": "collection",
+      "href": "./collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "./item_datacube_variables.json",
+      "type": "application/geo+json"
+    },
+    {
+      "rel": "via",
+      "href": "https://github.com/robbiewatt1/ClimateDiffuse",
+      "type": "text/html"
+    }
+  ]
+}

--- a/examples/item_datacube_variables.json
+++ b/examples/item_datacube_variables.json
@@ -4,11 +4,11 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/mlm/v1.4.0/schema.json",
     "https://stac-extensions.github.io/datacube/v2.3.0/schema.json",
-    "https://stac-extensions.github.io/ml-aoi/v0.2.0/schema.json",
+    "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "type": "Feature",
-  "id": "UNet_ClimateDiffuse_Regression",
+  "id": "UNet_ClimateDiffuse_ERA5_Regression",
   "collection": "ml-model-examples",
   "geometry": {
     "type": "Polygon",
@@ -44,16 +44,16 @@
     58.21798141355221
   ],
   "properties": {
-    "description": "UNet model for regression tasks of climate indices of SSP2-4.5 scenario using CMIP6 dataset.",
+    "description": "UNet model for regression tasks of climate indices of ERA5 dataset.",
     "datetime": null,
-    "start_datetime": "1900-01-01T00:00:00Z",
+    "start_datetime": "1940-01-01T00:00:00Z",
     "end_datetime": "2100-12-31T23:59:59Z",
-    "mlm:name": "UNet ClimateDiffuse Regression",
+    "mlm:name": "UNet ClimateDiffuse ERA5 Regression",
     "mlm:tasks": [
       "regression"
     ],
     "mlm:architecture": "U-Net",
-    "mlm:framework": "torchgeo",
+    "mlm:framework": "pytorch",
     "mlm:framework_version": "0.8.0.dev0",
     "mlm:accelerator": "cuda",
     "mlm:accelerator_constrained": false,
@@ -62,10 +62,9 @@
       {
         "name": "Climate Variables employed by the model for regression.",
         "variables": [
-          "air_temperature",
-          "soil_moisture_content",
-          "surface_temperature",
-          "surface_air_pressure"
+          "VAR_2T",
+          "VAR_10U",
+          "VAR_10V"
         ],
         "input": {
           "shape": [
@@ -83,7 +82,14 @@
           "data_type": "float32"
         },
         "norm_by_channel": false,
-        "resize_type": null
+        "resize_type": null,
+        "pre_processing_function": {
+          "format": "uri",
+          "expression": {
+            "href": "https://raw.githubusercontent.com/robbiewatt1/ClimateDiffuse/refs/heads/main/download_ERA5/preprocessing_concat_year.py",
+            "type": "text/x-python"
+          }
+        }
       }
     ],
     "mlm:output": [
@@ -117,16 +123,27 @@
     }
   ],
   "assets": {
-    "weights": {
-      "href": "https://huggingface.co/torchgeo/resnet18_sentinel2_all_moco/resolve/main/resnet18_sentinel2_all_moco-59bfdff9.pth",
-      "title": "Pytorch weights checkpoint",
-      "description": "A Resnet-18 classification model trained on normalized Sentinel-2 imagery with Eurosat landcover labels with torchgeo",
+    "weights-unet": {
+      "href": "https://github.com/robbiewatt1/ClimateDiffuse/raw/refs/heads/main/Model_chpt/unet.pt",
+      "title": "U-Net Pytorch weights checkpoint",
       "type": "application/octet-stream; application=pytorch",
       "roles": [
         "mlm:model",
         "mlm:weights"
       ],
-      "mlm:artifact_type": "torch.save"
+      "mlm:artifact_type": "torch.save",
+      "file:size": 389657415
+    },
+    "weights-diffusion": {
+      "href": "https://github.com/robbiewatt1/ClimateDiffuse/raw/refs/heads/main/Model_chpt/diffusion.pt",
+      "title": "Diffusion Pytorch weights checkpoint",
+      "type": "application/octet-stream; application=pytorch",
+      "roles": [
+        "mlm:model",
+        "mlm:weights"
+      ],
+      "mlm:artifact_type": "torch.save",
+      "file:size": 389695738
     },
     "source_code": {
       "href": "https://raw.githubusercontent.com/robbiewatt1/ClimateDiffuse/refs/heads/main/src/Network.py",
@@ -154,6 +171,11 @@
     {
       "rel": "via",
       "href": "https://github.com/robbiewatt1/ClimateDiffuse",
+      "type": "text/html"
+    },
+    {
+      "rel": "cite-as",
+      "href": "https://doi.org/10.48550/arXiv.2404.17752",
       "type": "text/html"
     }
   ]

--- a/examples/item_datacube_variables.json
+++ b/examples/item_datacube_variables.json
@@ -97,9 +97,8 @@
       }
     ]
   },
-  "cube:dimensions": [
-    {
-      "name": "time",
+  "cube:dimensions": {
+    "time": {
       "type": "temporal",
       "extent": [
         "1940-01-01T00:00:00Z",
@@ -107,8 +106,7 @@
       ],
       "step": "P1H"
     },
-    {
-      "name": "lat",
+    "lat": {
       "type": "spatial",
       "extent": [
         54.2,
@@ -116,8 +114,7 @@
       ],
       "axis": "y"
     },
-    {
-      "name": "lon",
+    "lon": {
       "type": "spatial",
       "extent": [
         233.6,
@@ -125,10 +122,9 @@
       ],
       "axis": "x"
     }
-  ],
-  "cube:variables": [
-    {
-      "name": "land_sea_mask",
+  },
+  "cube:variables": {
+    "land_sea_mask": {
       "shortname": "lsm",
       "description": "Proportion of land-sea, where 1 indicates land and 0 indicates sea.",
       "type": "data",
@@ -137,8 +133,7 @@
       "dimensions": ["lat", "lon"],
       "definition": "https://codes.ecmwf.int/grib/param-db/172"
     },
-    {
-      "name": "geopotential",
+    "geopotential": {
       "shortname": "z",
       "description": "This parameter is the geopotential, which is the potential energy per unit mass at a point in the atmosphere, expressed in metres squared per second squared (m² s⁻²). It is a measure of the height of a point in the atmosphere relative to sea level.",
       "type": "data",
@@ -147,8 +142,7 @@
       "dimensions": ["lat", "lon"],
       "definition": "https://codes.ecmwf.int/grib/param-db/129"
     },
-    {
-      "name": "2m_temperature",
+    "2m_temperature": {
       "description": "This parameter is the temperature of air at 2m above the surface of land, sea or in-land waters.",
       "type": "data",
       "data_type": "float32",
@@ -156,8 +150,7 @@
       "dimensions": ["time", "lat", "lon"],
       "definition": "https://codes.ecmwf.int/grib/param-db/167"
     },
-    {
-      "name": "10m_u_component_of_wind",
+    "10m_u_component_of_wind": {
       "shortname": "10u",
       "description": "This parameter is the eastward component of the 10m wind. It is the horizontal speed of air moving towards the east, at a height of ten metres above the surface of the Earth, in metres per second.",
       "type": "data",
@@ -166,8 +159,7 @@
       "dimensions": ["time", "lat", "lon"],
       "definition": "https://codes.ecmwf.int/grib/param-db/165"
     },
-    {
-      "name": "10m_v_component_of_wind",
+    "10m_v_component_of_wind": {
       "shortname": "10v",
       "description": "This parameter is the northward component of the 10m wind. It is the horizontal speed of air moving towards the north, at a height of ten metres above the surface of the Earth, in metres per second.",
       "type": "data",
@@ -176,7 +168,7 @@
       "dimensions": ["time", "lat", "lon"],
       "definition": "https://codes.ecmwf.int/grib/param-db/166"
     }
-  ],
+  },
   "sci:publications": [
     {
       "doi": "10.48550/arXiv.2404.17752",

--- a/examples/item_datacube_variables.json
+++ b/examples/item_datacube_variables.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Demonstrate the use of MLM and EO for bands description, with EO bands directly in the Model Asset.",
+  "$comment": "Demonstrate the use of MLM and DataCube variables description.",
   "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/mlm/v1.4.0/schema.json",
@@ -8,85 +8,60 @@
     "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
   ],
   "type": "Feature",
-  "id": "UNet_ClimateDiffuse_ERA5_Regression",
+  "id": "UNet_ClimateDiffuse_ERA5_Downscaling",
   "collection": "ml-model-examples",
+  "bbox": [233.6, 54.2, 297.5, 22.6],
   "geometry": {
     "type": "Polygon",
-    "coordinates": [
-      [
-        [
-          -7.882190080512502,
-          37.13739173208318
-        ],
-        [
-          -7.882190080512502,
-          58.21798141355221
-        ],
-        [
-          27.911651652899923,
-          58.21798141355221
-        ],
-        [
-          27.911651652899923,
-          37.13739173208318
-        ],
-        [
-          -7.882190080512502,
-          37.13739173208318
-        ]
-      ]
-    ]
+    "coordinates": [[[233.6, 54.2], [297.5, 54.2], [297.5, 22.6], [233.6, 22.6], [233.6, 54.2]]]
   },
-  "bbox": [
-    -7.882190080512502,
-    37.13739173208318,
-    27.911651652899923,
-    58.21798141355221
-  ],
   "properties": {
-    "description": "UNet model for regression tasks of climate indices of ERA5 dataset.",
+    "description": "UNet model for coarse-to-fine downscaling as regression task of climate indices of ERA5 dataset.",
     "datetime": null,
     "start_datetime": "1940-01-01T00:00:00Z",
     "end_datetime": "2100-12-31T23:59:59Z",
-    "mlm:name": "UNet ClimateDiffuse ERA5 Regression",
+    "mlm:name": "UNet ClimateDiffuse ERA5 Downscaling",
     "mlm:tasks": [
-      "regression"
+      "regression",
+      "downscaling"
     ],
     "mlm:architecture": "U-Net",
     "mlm:framework": "pytorch",
-    "mlm:framework_version": "0.8.0.dev0",
+    "mlm:framework_version": "2.1.2+cu118",
     "mlm:accelerator": "cuda",
     "mlm:accelerator_constrained": false,
-    "mlm:accelerator_summary": "Unknown",
     "mlm:input": [
       {
-        "name": "Climate Variables employed by the model for regression.",
+        "name": "Coarse climate variables employed by the model downscaling regression. This model takes 2 'constant/spatial' variables and 3 'spatio-temporal' variables provided by ERA5 datacube.",
         "variables": [
-          "VAR_2T",
-          "VAR_10U",
-          "VAR_10V"
+          "land_sea_mask",
+          "geopotential",
+          "temperature_2m",
+          "10m_u_component_of_wind",
+          "10m_v_component_of_wind"
         ],
         "input": {
           "shape": [
             -1,
-            4,
-            256,
+            5,
+            128,
             256
           ],
           "dim_order": [
-            "batch",
+            "time",
             "variables",
-            "height",
-            "width"
+            "lat",
+            "lon"
           ],
           "data_type": "float32"
         },
         "norm_by_channel": false,
         "resize_type": null,
         "pre_processing_function": {
+          "description": "Script that performs the relevant normalization and concatenation of variables for model input.",
           "format": "uri",
           "expression": {
-            "href": "https://raw.githubusercontent.com/robbiewatt1/ClimateDiffuse/refs/heads/main/download_ERA5/preprocessing_concat_year.py",
+            "href": "https://raw.githubusercontent.com/robbiewatt1/ClimateDiffuse/refs/heads/main/src/DatasetUS.py",
             "type": "text/x-python"
           }
         }
@@ -94,27 +69,113 @@
     ],
     "mlm:output": [
       {
-        "name": "forecast",
+        "name": "Fine climate variables predicted by the model. Only the 3 'spatio-temporal' variables are predicted.",
         "tasks": [
-          "regression"
+          "regression",
+          "downscaling"
+        ],
+        "variables": [
+          "temperature_2m",
+          "10m_u_component_of_wind",
+          "10m_v_component_of_wind"
         ],
         "result": {
           "shape": [
             -1,
-            256,
+            3,
+            128,
             256
           ],
           "dim_order": [
-            "precipitation_flux",
-            "class"
+            "time",
+            "variables",
+            "lat",
+            "lon"
           ],
           "data_type": "float32"
         }
       }
     ]
   },
-  "$comment": "Following 'cube:variables' is required to fulfil schema validation. Each 'name' refers to variables used in 'mlm:input' and 'mlm:output'.",
+  "cube:dimensions": [
+    {
+      "name": "time",
+      "type": "temporal",
+      "extent": [
+        "1940-01-01T00:00:00Z",
+        "2100-12-31T23:59:59Z"
+      ],
+      "step": "P1H"
+    },
+    {
+      "name": "lat",
+      "type": "spatial",
+      "extent": [
+        54.2,
+        22.6
+      ],
+      "axis": "y"
+    },
+    {
+      "name": "lon",
+      "type": "spatial",
+      "extent": [
+        233.6,
+        297.5
+      ],
+      "axis": "x"
+    }
+  ],
   "cube:variables": [
+    {
+      "name": "land_sea_mask",
+      "shortname": "lsm",
+      "description": "Proportion of land-sea, where 1 indicates land and 0 indicates sea.",
+      "type": "data",
+      "data_type": "float32",
+      "extent": [0, 1],
+      "dimensions": ["lat", "lon"],
+      "definition": "https://codes.ecmwf.int/grib/param-db/172"
+    },
+    {
+      "name": "geopotential",
+      "shortname": "z",
+      "description": "This parameter is the geopotential, which is the potential energy per unit mass at a point in the atmosphere, expressed in metres squared per second squared (m² s⁻²). It is a measure of the height of a point in the atmosphere relative to sea level.",
+      "type": "data",
+      "data_type": "float32",
+      "unit": "m² s-2",
+      "dimensions": ["lat", "lon"],
+      "definition": "https://codes.ecmwf.int/grib/param-db/129"
+    },
+    {
+      "name": "2m_temperature",
+      "description": "This parameter is the temperature of air at 2m above the surface of land, sea or in-land waters.",
+      "type": "data",
+      "data_type": "float32",
+      "unit": "K",
+      "dimensions": ["time", "lat", "lon"],
+      "definition": "https://codes.ecmwf.int/grib/param-db/167"
+    },
+    {
+      "name": "10m_u_component_of_wind",
+      "shortname": "10u",
+      "description": "This parameter is the eastward component of the 10m wind. It is the horizontal speed of air moving towards the east, at a height of ten metres above the surface of the Earth, in metres per second.",
+      "type": "data",
+      "data_type": "float32",
+      "unit": "m s-1",
+      "dimensions": ["time", "lat", "lon"],
+      "definition": "https://codes.ecmwf.int/grib/param-db/165"
+    },
+    {
+      "name": "10m_v_component_of_wind",
+      "shortname": "10v",
+      "description": "This parameter is the northward component of the 10m wind. It is the horizontal speed of air moving towards the north, at a height of ten metres above the surface of the Earth, in metres per second.",
+      "type": "data",
+      "data_type": "float32",
+      "unit": "m s-1",
+      "dimensions": ["time", "lat", "lon"],
+      "definition": "https://codes.ecmwf.int/grib/param-db/166"
+    }
   ],
   "sci:publications": [
     {
@@ -123,7 +184,7 @@
     }
   ],
   "assets": {
-    "weights-unet": {
+    "weights": {
       "href": "https://github.com/robbiewatt1/ClimateDiffuse/raw/refs/heads/main/Model_chpt/unet.pt",
       "title": "U-Net Pytorch weights checkpoint",
       "type": "application/octet-stream; application=pytorch",
@@ -134,28 +195,39 @@
       "mlm:artifact_type": "torch.save",
       "file:size": 389657415
     },
-    "weights-diffusion": {
-      "href": "https://github.com/robbiewatt1/ClimateDiffuse/raw/refs/heads/main/Model_chpt/diffusion.pt",
-      "title": "Diffusion Pytorch weights checkpoint",
-      "type": "application/octet-stream; application=pytorch",
-      "roles": [
-        "mlm:model",
-        "mlm:weights"
-      ],
-      "mlm:artifact_type": "torch.save",
-      "file:size": 389695738
-    },
-    "source_code": {
+    "model": {
       "href": "https://raw.githubusercontent.com/robbiewatt1/ClimateDiffuse/refs/heads/main/src/Network.py",
       "title": "Model implementation.",
-      "description": "Source code to run the model.",
+      "description": "Source code to define the U-Net model.",
       "type": "text/x-python",
       "roles": [
         "mlm:source_code",
         "code",
         "metadata"
       ]
+    },
+    "train-script": {
+      "href": "https://raw.githubusercontent.com/robbiewatt1/ClimateDiffuse/refs/heads/main/src/TrainUnet.py",
+      "title": "Training script.",
+      "description": "Script to run training of the model.",
+      "type": "text/x-python",
+      "roles": [
+        "mlm:training",
+        "code",
+        "metadata"
+      ]
     }
+  },
+  "inference-script": {
+    "href": "https://raw.githubusercontent.com/robbiewatt1/ClimateDiffuse/refs/heads/main/src/Inference.py",
+    "title": "Inference script.",
+    "description": "Script to run inference with the model.",
+    "type": "text/x-python",
+    "roles": [
+      "mlm:inference",
+      "code",
+      "metadata"
+    ]
   },
   "links": [
     {
@@ -176,6 +248,11 @@
     {
       "rel": "cite-as",
       "href": "https://doi.org/10.48550/arXiv.2404.17752",
+      "type": "text/html"
+    },
+    {
+      "rel": "code",
+      "href": "https://github.com/robbiewatt1/ClimateDiffuse",
       "type": "text/html"
     }
   ]

--- a/examples/item_eo_bands.json
+++ b/examples/item_eo_bands.json
@@ -4,7 +4,6 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/mlm/v1.4.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v1.0.0/schema.json",
     "https://stac-extensions.github.io/ml-aoi/v0.2.0/schema.json"
   ],

--- a/examples/item_eo_bands_summarized.json
+++ b/examples/item_eo_bands_summarized.json
@@ -4,7 +4,6 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/mlm/v1.4.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/file/v1.0.0/schema.json",
     "https://stac-extensions.github.io/ml-aoi/v0.2.0/schema.json"
   ],

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -141,10 +141,10 @@
       "properties": {
         "properties": {
           "required": [
-            "eo:bands"
+            "cube:variables"
           ],
           "properties": {
-            "eo:bands": {
+            "cube:variables": {
               "type": "array",
               "minItems": 1,
               "items": {
@@ -168,10 +168,10 @@
             },
             "then": {
               "required": [
-                "eo:bands"
+                "cube:variables"
               ],
               "properties": {
-                "eo:bands": {
+                "cube:variables": {
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -1188,40 +1188,79 @@
         ]
       }
     },
-    "AnyBandsRef": {
-      "$comment": "This definition ensures that, if at least 1 named MLM input 'bands' is provided, at least 1 of the supported references from EO, Raster or STAC Core 1.1 are provided as well. Otherwise, 'bands' must be explicitly empty.",
-      "if": {
-        "type": "object",
-        "$comment": "This is the JSON-object 'properties' definition, which describes the STAC-Item field named 'properties'.",
+    "AnyBandInputRef": {
+      "type": "object",
+      "$comment": "This is the JSON-object 'properties' definition, which describes the STAC-Item field named 'properties'.",
+      "properties": {
         "properties": {
+          "type": "object",
+          "required": [
+            "mlm:input"
+          ],
+          "$comment": "This is the JSON-object 'properties' definition for the MLM input with bands listing referring to at least one band name.",
           "properties": {
-            "type": "object",
-            "required": [
-              "mlm:input"
-            ],
-            "$comment": "This is the JSON-object 'properties' definition for the MLM input with bands listing referring to at least one band name.",
-            "properties": {
-              "mlm:input": {
-                "type": "array",
-                "$comment": "Below 'minItems' ensures that band check does not fail for explicitly empty 'mlm:input'.",
-                "minItems": 1,
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "bands"
-                  ],
-                  "$comment": "This is the 'Model Input Object' properties.",
-                  "properties": {
-                    "bands": {
-                      "type": "array",
-                      "minItems": 1
-                    }
+            "mlm:input": {
+              "type": "array",
+              "$comment": "Below 'minItems' ensures that band check does not fail for explicitly empty 'mlm:input'.",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "bands"
+                ],
+                "$comment": "This is the 'Model Input Object' properties.",
+                "properties": {
+                  "bands": {
+                    "type": "array",
+                    "minItems": 1
                   }
                 }
               }
             }
           }
         }
+      }
+    },
+    "AnyBandOutputRef": {
+      "type": "object",
+      "$comment": "This is the JSON-object 'properties' definition, which describes the STAC-Item field named 'properties'.",
+      "properties": {
+        "properties": {
+          "type": "object",
+          "required": [
+            "mlm:output"
+          ],
+          "$comment": "This is the JSON-object 'properties' definition for the MLM output with bands listing referring to at least one band name.",
+          "properties": {
+            "mlm:output": {
+              "type": "array",
+              "$comment": "Below 'minItems' ensures that band check does not fail for explicitly empty 'mlm:output'.",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "bands"
+                ],
+                "$comment": "This is the 'Model Output Object' properties.",
+                "properties": {
+                  "bands": {
+                    "type": "array",
+                    "minItems": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "AnyBandsRef": {
+      "$comment": "This definition ensures that, if at least 1 named MLM input 'bands' is provided, at least 1 of the supported references from EO, Raster or STAC Core 1.1 are provided as well. Otherwise, 'bands' must be explicitly empty.",
+      "if": {
+        "anyOf": [
+          {"$ref": "#/$defs/AnyBandInputRef"},
+          {"$ref": "#/$defs/AnyBandOutputRef"}
+        ]
       },
       "then": {
         "$comment": "Need at least one 'bands' definition, but multiple are allowed.",
@@ -1289,46 +1328,85 @@
         "$comment": "Case where no 'bands' (empty list) are referenced in the MLM input. Because models can use a mixture of inputs with/without bands, we cannot enforce eo/raster/stac bands references to be omitted. If bands are provided in the 'mlm:model', it will simply be an odd case if none are used in any 'mlm:input' bands."
       }
     },
-    "AnyVariablesRef": {
-      "$comment": "This definition ensures that, if at least 1 named MLM input 'variables' is provided, at least 1 of the supported references from STAC datacube is provided as well. Otherwise, 'variables' must be explicitly empty.",
-      "if": {
-        "type": "object",
-        "$comment": "This is the JSON-object 'properties' definition, which describes the STAC-Item field named 'properties'.",
+    "AnyVariablesInputRef": {
+      "type": "object",
+      "$comment": "This is the JSON-object 'properties' definition, which describes the STAC-Item field named 'properties'.",
+      "properties": {
         "properties": {
+          "type": "object",
+          "required": [
+            "mlm:input"
+          ],
+          "$comment": "This is the JSON-object 'properties' definition for the MLM input with variables listing referring to at least one variable name.",
           "properties": {
-            "type": "object",
-            "required": [
-              "mlm:input"
-            ],
-            "$comment": "This is the JSON-object 'properties' definition for the MLM input with variables listing referring to at least one variable name.",
-            "properties": {
-              "mlm:input": {
-                "type": "array",
-                "$comment": "Below 'minItems' ensures that band check does not fail for explicitly empty 'mlm:input'.",
-                "minItems": 1,
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "variables"
-                  ],
-                  "$comment": "This is the 'Model Input Object' properties.",
-                  "properties": {
-                    "variables": {
-                      "type": "array",
-                      "minItems": 1
-                    }
+            "mlm:input": {
+              "type": "array",
+              "$comment": "Below 'minItems' ensures that band check does not fail for explicitly empty 'mlm:input'.",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "variables"
+                ],
+                "$comment": "This is the 'Model Input Object' properties.",
+                "properties": {
+                  "variables": {
+                    "type": "array",
+                    "minItems": 1
                   }
                 }
               }
             }
           }
         }
+      }
+    },
+    "AnyVariablesOutputRef": {
+      "type": "object",
+      "$comment": "This is the JSON-object 'properties' definition, which describes the STAC-Item field named 'properties'.",
+      "properties": {
+        "properties": {
+          "type": "object",
+          "required": [
+            "mlm:output"
+          ],
+          "$comment": "This is the JSON-object 'properties' definition for the MLM output with variables listing referring to at least one variable name.",
+          "properties": {
+            "mlm:output": {
+              "type": "array",
+              "$comment": "Below 'minItems' ensures that band check does not fail for explicitly empty 'mlm:output'.",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "variables"
+                ],
+                "$comment": "This is the 'Model Output Object' properties.",
+                "properties": {
+                  "variables": {
+                    "type": "array",
+                    "minItems": 1
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "AnyVariablesRef": {
+      "$comment": "This definition ensures that, if at least 1 named MLM input 'variables' is provided, at least 1 of the supported references from STAC datacube is provided as well. Otherwise, 'variables' must be explicitly empty.",
+      "if": {
+        "anyOf": [
+          {"$ref": "#/$defs/AnyVariablesInputRef"},
+          {"$ref": "#/$defs/AnyVariablesOutputRef"}
+        ]
       },
       "then": {
         "$comment": "Need at least one 'variables' definition, but multiple are allowed (although for now, only 'datacube' is defined).",
         "anyOf": [
           {
-            "$comment": "Variables described by raster extension.",
+            "$comment": "Variables described by datacube extension.",
             "allOf": [
               {
                 "$ref": "#/$defs/stac_extensions_datacube_variables"

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -43,8 +43,12 @@
             "$ref": "#/$defs/stac_extensions_mlm"
           },
           {
-            "$comment": "Schema to validate cross-references of bands between MLM inputs and any 'bands'-compliant section describing them using another STAC definition.",
+            "$comment": "Schema to validate cross-references of bands between MLM inputs and any compliant section describing them using another STAC definition.",
             "$ref": "#/$defs/AnyBandsRef"
+          },
+          {
+            "$comment": "Schema to validate cross-references of variables between MLM inputs and any compliant section describing them using another STAC definition.",
+            "$ref": "#/$defs/AnyVariablesRef"
           },
           {
             "$comment": "Schema to validate that at least one Asset defines a model role.",
@@ -112,6 +116,70 @@
           "type": "array",
           "contains": {
             "const": "https://stac-extensions.github.io/mlm/v1.4.0/schema.json"
+          }
+        }
+      }
+    },
+    "stac_extensions_datacube_variables": {
+      "$comment": "STAC extension reference to [https://github.com/stac-extensions/datacube]. V2 and above is required to reference 'cube:variables'.",
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "type": "string",
+            "pattern": "https://stac-extensions\\.github\\.io/datacube/v2(\\.[0-9]+){2}/schema\\.json"
+          }
+        }
+      }
+    },
+    "stac_extensions_datacube_variables_item": {
+      "$comment": "This is the JSON-object 'properties' definition, which describes the STAC-Item field named 'properties' containing 'cube:variables' as described in [https://github.com/stac-extensions/datacube#fields].",
+      "properties": {
+        "properties": {
+          "required": [
+            "eo:bands"
+          ],
+          "properties": {
+            "eo:bands": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    },
+    "stac_extensions_datacube_variables_asset": {
+      "required": [
+        "assets"
+      ],
+      "$comment": "This is the JSON-object 'properties' definition, which describes the STAC-Asset containing 'cube:variables' as described in [https://github.com/stac-extensions/datacube#fields].",
+      "properties": {
+        "assets": {
+          "additionalProperties": {
+            "if": {
+              "$ref": "#/$defs/AssetModelRole"
+            },
+            "then": {
+              "required": [
+                "eo:bands"
+              ],
+              "properties": {
+                "eo:bands": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -602,7 +670,10 @@
     "mlm:input": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/ModelInput"
+        "allOf": [
+          {"$ref": "#/$defs/ModelInput"},
+          {"$ref": "#/$defs/ModelInputBandsVariables" }
+        ]
       }
     },
     "ModelInput": {
@@ -610,7 +681,6 @@
       "type": "object",
       "required": [
         "name",
-        "bands",
         "input"
       ],
       "properties": {
@@ -619,7 +689,10 @@
           "minLength": 1
         },
         "bands": {
-          "$ref": "#/$defs/ModelBands"
+          "$ref": "#/$defs/ModelBandsVariables"
+        },
+        "variables": {
+          "$ref": "#/$defs/ModelBandsVariables"
         },
         "input": {
           "$ref": "#/$defs/InputStructure"
@@ -638,6 +711,13 @@
           "$ref": "#/$defs/ProcessingExpression"
         }
       }
+    },
+    "ModelInputBandsVariables": {
+      "$comment": "Inputs can be described by either 'bands', 'variables' or both simultaneously to represent different kinds of data. Whichever one is employed, at least one must be provided, including at least an empty array when none applies.",
+      "anyOf": [
+        {"required": ["bands"]},
+        {"required": ["variables"]}
+      ]
     },
     "mlm:output": {
       "type": "array",
@@ -740,6 +820,10 @@
         "examples": [
           "batch",
           "channel",
+          "bands",
+          "variables",
+          "temperature",
+          "pressure",
           "time",
           "height",
           "width",
@@ -1047,19 +1131,19 @@
         }
       ]
     },
-    "ModelBands": {
-      "description": "List of bands (if any) that compose the input. Band order represents the index position of the bands.",
+    "ModelBandsVariables": {
+      "description": "List of bands or variables (if any) that compose the input. Band and/or variable order represents the index position within the input. If both bands and variables are provided, their other should be distinguished using corresponding names in 'dim_order'.",
       "$comment": "No 'minItems' here to support model inputs not using any band (other data source).",
       "type": "array",
       "items": {
         "oneOf": [
           {
-            "description": "Implied named-band with the name directly provided.",
+            "description": "Implied name of the band or variable with the name directly provided with no further properties.",
             "type": "string",
             "minLength": 1
           },
           {
-            "description": "Explicit named-band with optional derived expression to obtain it.",
+            "description": "Explicitly named band or variable with optional derived expression to obtain it.",
             "type": "object",
             "required": [
               "name"
@@ -1106,7 +1190,7 @@
             "properties": {
               "mlm:input": {
                 "type": "array",
-                "$comment": "Below 'minItems' ensures that band check does not fail for explicitly empty 'mlm:inputs'.",
+                "$comment": "Below 'minItems' ensures that band check does not fail for explicitly empty 'mlm:input'.",
                 "minItems": 1,
                 "items": {
                   "type": "object",
@@ -1189,7 +1273,69 @@
         ]
       },
       "else": {
-        "$comment": "Case where no 'bands' (empty list) are referenced in the MLM input. Because models can use a mixture of inputs with/without bands, we cannot enforce eo/raster/stac bands references to be omitted. If bands are provided in the 'mlm:model', it will simply be an odd case if none are used in any 'mlm:input' bands'."
+        "$comment": "Case where no 'bands' (empty list) are referenced in the MLM input. Because models can use a mixture of inputs with/without bands, we cannot enforce eo/raster/stac bands references to be omitted. If bands are provided in the 'mlm:model', it will simply be an odd case if none are used in any 'mlm:input' bands."
+      }
+    },
+    "AnyVariablesRef": {
+      "$comment": "This definition ensures that, if at least 1 named MLM input 'variables' is provided, at least 1 of the supported references from STAC datacube is provided as well. Otherwise, 'variables' must be explicitly empty.",
+      "if": {
+        "type": "object",
+        "$comment": "This is the JSON-object 'properties' definition, which describes the STAC-Item field named 'properties'.",
+        "properties": {
+          "properties": {
+            "type": "object",
+            "required": [
+              "mlm:input"
+            ],
+            "$comment": "This is the JSON-object 'properties' definition for the MLM input with variables listing referring to at least one variable name.",
+            "properties": {
+              "mlm:input": {
+                "type": "array",
+                "$comment": "Below 'minItems' ensures that band check does not fail for explicitly empty 'mlm:input'.",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "variables"
+                  ],
+                  "$comment": "This is the 'Model Input Object' properties.",
+                  "properties": {
+                    "variables": {
+                      "type": "array",
+                      "minItems": 1
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "$comment": "Need at least one 'variables' definition, but multiple are allowed (although for now, only 'datacube' is defined).",
+        "anyOf": [
+          {
+            "$comment": "Variables described by raster extension.",
+            "allOf": [
+              {
+                "$ref": "#/$defs/stac_extensions_datacube_variables"
+              },
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/stac_extensions_datacube_variables_item"
+                  },
+                  {
+                    "$ref": "#/$defs/stac_extensions_datacube_variables_asset"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "else": {
+        "$comment": "Case where no 'variables' (empty list) are referenced in the MLM input. Because models can use a mixture of inputs with/without variables, we cannot enforce their references to be omitted. If variables are provided in the 'mlm:model', it will simply be an odd case if none are used in any 'mlm:input' variables."
       }
     }
   }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -567,7 +567,8 @@
           "similarity-search",
           "generative",
           "image-captioning",
-          "super-resolution"
+          "super-resolution",
+          "downscaling"
         ]
       }
     },
@@ -722,34 +723,46 @@
     "mlm:output": {
       "type": "array",
       "items": {
-        "title": "Model Output Object",
-        "type": "object",
-        "required": [
-          "name",
-          "tasks",
-          "result"
-        ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "minLength": 1
-          },
-          "tasks": {
-            "$ref": "#/$defs/mlm:tasks"
-          },
-          "result": {
-            "$ref": "#/$defs/ResultStructure"
-          },
-          "description": {
-            "type": "string",
-            "minLength": 1
-          },
-          "classification:classes": {
-            "$ref": "#/$defs/ClassificationClasses"
-          },
-          "post_processing_function": {
-            "$ref": "#/$defs/ProcessingExpression"
-          }
+        "$comment": "Contrary to inputs, 'bands' and 'variables' are not requires by outputs for backward compatibility. However, they can be supplied if applicable.",
+        "allOf": [
+          {"$ref": "#/$defs/ModelOutput"}
+        ]
+      }
+    },
+    "ModelOutput": {
+      "title": "Model Output Object",
+      "type": "object",
+      "required": [
+        "name",
+        "tasks",
+        "result"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tasks": {
+          "$ref": "#/$defs/mlm:tasks"
+        },
+        "result": {
+          "$ref": "#/$defs/ResultStructure"
+        },
+        "bands": {
+          "$ref": "#/$defs/ModelBandsVariables"
+        },
+        "variables": {
+          "$ref": "#/$defs/ModelBandsVariables"
+        },
+        "classification:classes": {
+          "$ref": "#/$defs/ClassificationClasses"
+        },
+        "post_processing_function": {
+          "$ref": "#/$defs/ProcessingExpression"
         }
       }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -328,7 +328,7 @@ exclude_also = [
   "def main",
   "if __name__ == .__main__.:"
 ]
-fail_under = 50
+fail_under = 80
 show_missing = true
 
 [tool.coverage.paths]

--- a/stac_model/__main__.py
+++ b/stac_model/__main__.py
@@ -35,7 +35,7 @@ def main(
 ) -> ItemMLModelExtension:
     """Generate example spec."""
     ml_model_meta = eurosat_resnet()
-    with open("example.json", "w") as json_file:
+    with open("example.json", mode="w", encoding="utf-8") as json_file:
         json.dump(ml_model_meta.item.to_dict(), json_file, indent=4)
     print("Example model metadata written to ./example.json.")
     return ml_model_meta

--- a/stac_model/base.py
+++ b/stac_model/base.py
@@ -87,6 +87,7 @@ class TaskEnum(str, Enum):
     GENERATIVE = "generative"
     IMAGE_CAPTIONING = "image-captioning"
     SUPER_RESOLUTION = "super-resolution"
+    DOWNSCALING = "downscaling"
 
 
 ModelTaskNames: TypeAlias = Literal[
@@ -103,6 +104,7 @@ ModelTaskNames: TypeAlias = Literal[
     "generative",
     "image-captioning",
     "super-resolution",
+    "downscaling",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def get_all_stac_item_examples() -> list[str]:
 
 @pytest.fixture(scope="session")
 def mlm_schema() -> JSON:
-    with open(os.path.join(JSON_SCHEMA_DIR, "schema.json")) as schema_file:
+    with open(os.path.join(JSON_SCHEMA_DIR, "schema.json"), mode="r", encoding="utf-8") as schema_file:
         data = json.load(schema_file)
     return cast(JSON, data)
 
@@ -59,7 +59,7 @@ def mlm_validator(
 
 @pytest.fixture
 def mlm_example(request: "SubRequest") -> dict[str, JSON]:
-    with open(os.path.join(EXAMPLES_DIR, request.param)) as example_file:
+    with open(os.path.join(EXAMPLES_DIR, request.param), mode="r", encoding="utf-8") as example_file:
         data = json.load(example_file)
     return cast(dict[str, JSON], data)
 


### PR DESCRIPTION
## Description

- Add `variables` properties to [Model Input Object](README.md#model-input-object) to allow specifying the relevant data variables used by the model, with cross-references to the [datacube](https://github.com/stac-extensions/datacube) extension (relates to [#90](https://github.com/stac-extensions/mlm/issues/90)).
- Add `bands` and `variables` properties to [Model Output Object](README.md#model-output-object) to allow specifying the relevant bands or variables produced by the model if any applies.
- Add `downscaling` to [Tasks](./README.md#task-enum) as common operation for climate variable models.
- Refactor the JSON schema to check for `bands` and `variables` references within both `mlm:input` and `mlm:output`.   If either location detects that either `bands` or `variables` is provided, their corresponding sets of extensions providing relevant descriptions are verified.
- Refactor the JSON schema `mlm:output` property to employ a `ModelOutput` object definition rather than directly provided properties nested under the array.
- Refactor the JSON schema to allow the omission of `bands` under `mlm:input` if the `variables` property is provided.
- Fix missing ``encoding="utf-8"`` parameters in `open` calls leading to failing parsing of example JSON STAC Item when they contain non-ASCII characters.
- Fix parsing of `PYTHON_PATH` in `Makefile` for Windows OS.

## Related Issue

- Fixes https://github.com/stac-extensions/mlm/issues/90

## Type of Change

- [x] :books: Examples, docs, tutorials or dependencies update;
- [x] :wrench: Bug fix (non-breaking change which fixes an issue);
- [x] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [x] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md) guide;
- [ ] I've updated the code style using `make check`;
- [x] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
