### PR TITLE
fix `mlm:entrypoint` checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Enforce `roles: ["code"]` (minimally) to be included if an Asset specified `mlm:entrypoint`.
 - Update `stac-model==0.4.0` to provide corresponding additions for `variables` reference.
 - Refactor `ModelInput` and `ModelOutput` objects to use a new `ModelBandsOrVariablesReferences` definition
   combining the `ModelBand` and `ModelDataVariable` lists.
@@ -58,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix JSON schema not allowing `mlm:entrypoint` to be defined under a [Source Code Asset](README.md#source-code-asset).
 - Fix `stac_model.output.ModelOutput` enforcing the need to specify `classification:classes` or `classes`.
   The property can now be omitted if the model does not need to indicate that it produces a classification output.
 - Fix missing ``encoding="utf-8"`` parameters in `open` calls leading to failing parsing of example JSON STAC Item

--- a/README.md
+++ b/README.md
@@ -864,27 +864,35 @@ See the [Best Practices - Framework Specific Artifact Types](./best-practices.md
 
 ### Source Code Asset
 
-| Field Name     | Type      | Description                                                                   |
-|----------------|-----------|-------------------------------------------------------------------------------|
-| title          | string    | Title of the source code.                                                     |
-| href           | string    | URI to the code repository, a ZIP archive, or an individual code/script file. |
-| type           | string    | Media-type of the URI.                                                        |
-| roles          | \[string] | **RECOMMENDED** Specify one or more of `["model", "code", "metadata"]`        |
-| description    | string    | Description of the source code.                                               |
-| mlm:entrypoint | string    | Specific entrypoint reference in the code to use for running model inference. |
+| Field Name     | Type      | Description                                                                                                               |
+|----------------|-----------|---------------------------------------------------------------------------------------------------------------------------|
+| title          | string    | Title of the source code.                                                                                                 |
+| href           | string    | URI to the code repository, a ZIP archive, or an individual code/script file.                                             |
+| type           | string    | Media-type of the URI.                                                                                                    |
+| roles          | \[string] | **RECOMMENDED** Specify one or more of `["model", "code", "metadata"]`.                                                   |
+| description    | string    | Description of the source code.                                                                                           |
+| mlm:entrypoint | string    | Specific entrypoint reference in the code to use for running model inference. If specified, the `code` role is MANDATORY. |
 
-If the referenced code does not directly offer a callable script to run the model, the `mlm:entrypoint` field should be
-added to the [Asset Object][stac-asset] in order to provide a pointer to the inference function to execute the model.
-For example, `my_package.my_module:predict` would refer to the `predict` function located in the `my_module` inside the
-`my_package` library provided by the repository.
+If the referenced code does not directly offer a callable script to run the model
+(i.e.: calling the script automatically resolves into invoking model inference within input data),
+then the `mlm:entrypoint` field should be provided into an [Asset Object][stac-asset] in order to provide
+a pointer to the inference function to execute the model.
+For example, using a Python script, a `mlm:entrypoint` value of `"my_package.my_module:predict"` would refer
+to the `predict` function located in the `my_module` inside the `my_package` library provided by the repository.
 
 It is strongly recommended to use a specific media-type such as `text/x-python` if the source code refers directly
 to a script of a known programming language. Using the HTML rendering of that source file, such as though GitHub
-for example, should be avoided. Using the "Raw Contents" endpoint for such cases is preferable.
-The `text/html` media-type should be reserved for cases where the URI generally points at a Git repository.
-Note that the URI including the specific commit hash, release number or target branch should be preferred over
-other means of referring to checkout procedures, although this specification does not prohibit the use of additional
-properties to better describe the Asset.
+for example, should be avoided. It is preferable to provide the "Raw Contents" endpoint of the script to facilitate
+its invocation without additional parsing to retrieve the source code.
+The `text/html` media-type can be used for identification purpose using the URI referring to a version control 
+repository such as Git, and where the `mlm:entrypoint` function can be easily resolved, through the corresponding 
+package installed from PyPI. 
+
+If an URI to a version control system is employed, it is recommended that it includes a specific commit hash, a
+release number, a target branch or Git tag in order to ensure correct resolution of the specific model being described.
+Embedded this information into the URI is recommended over other means of referring to checkout procedures simple to
+facilitate the retrieval of the source code with a single reference, although this specification does not prohibit
+the use of additional properties to better describe the Asset as needed.
 
 Since the source code of a model provides useful example on how to use it, it is also recommended to define relevant
 references to documentation using the `example` extension.

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -55,6 +55,10 @@
             "$ref": "#/$defs/AssetModelRoleMinimumOneDefinition"
           },
           {
+            "$comment": "Schema to validate any Asset containing an entrypoint is associated with code role.",
+            "$ref": "#/$defs/AssetCodeRoleWithEntrypoint"
+          },
+          {
             "$comment": "Schema to validate that the Asset model properties are mutually exclusive to the model role.",
             "$ref": "#/$defs/AssetModelRequiredProperties"
           }
@@ -364,6 +368,9 @@
         },
         "mlm:compile_method": {
           "$ref": "#/$defs/mlm:compile_method"
+        },
+        "mlm:entrypoint": {
+          "$ref": "#/$defs/mlm:entrypoint"
         }
       },
       "$comment": "Allow properties not defined by MLM prefix to work with other extensions and attributes, but disallow undefined MLM fields.",
@@ -416,7 +423,8 @@
           "not": {
             "anyOf": [
               {"required": ["mlm:artifact_type"]},
-              {"required": ["mlm:compile_method"]}
+              {"required": ["mlm:compile_method"]},
+              {"required": ["mlm:entrypoint"]}
             ]
           }
         },
@@ -538,6 +546,15 @@
       "examples": [
         "aot",
         "jit"
+      ]
+    },
+    "mlm:entrypoint": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Entrypoint script or function where the model can be invoked for inference on input data.",
+      "examples": [
+        "my_package.my_module:inference_function",
+        "inference.py"
       ]
     },
     "mlm:tasks": {
@@ -1117,6 +1134,42 @@
           }
         }
       ]
+    },
+    "AssetCodeRoleWithEntrypoint": {
+      "$comment": "Used to check the presence of 'code' role if an entrypoint is provided in an Asset.",
+      "properties": {
+        "assets": {
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "required": [
+                  "mlm:entrypoint",
+                  "roles"
+                ],
+                "properties": {
+                  "mlm:entrypoint": {
+                    "$ref": "#/$defs/mlm:entrypoint"
+                  },
+                  "roles": {
+                    "type": "array",
+                    "contains": {
+                      "const": "code"
+                    },
+                    "minItems": 1
+                  }
+                }
+              },
+              {
+                "not": {
+                  "required": [
+                    "mlm:entrypoint"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
     },
     "ModelBandsVariables": {
       "description": "List of bands or variables (if any) that compose the input. Band and/or variable order represents the index position within the input. If both bands and variables are provided, their other should be distinguished using corresponding names in 'dim_order'.",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -353,3 +353,76 @@ def test_collection_include_all_items(mlm_example):
     col_items = {os.path.basename(link["href"]) for link in col_links if link["rel"] == "item"}
     all_items = {os.path.basename(path) for path in get_all_stac_item_examples()}
     assert all_items == col_items, "Missing STAC Item examples in the example STAC Collection links."
+
+
+@pytest.mark.parametrize(
+    "mlm_example",
+    ["item_basic.json"],
+    indirect=True,
+)
+def test_mlm_entrypoint_asset_allowed(
+    mlm_validator: STACValidator,
+    mlm_example: dict[str, JSON],
+) -> None:
+    mlm_data = copy.deepcopy(mlm_example)
+    mlm_item = pystac.Item.from_dict(mlm_data)
+    pystac.validation.validate(mlm_item, validator=mlm_validator)  # self-check valid beforehand
+
+    mlm_data["assets"]["runtime"] = {
+        "type": "text/x-python",
+        "href": "https://example.com/package/",
+        "roles": ["code", "mlm:source_code", "mlm:inference-runtime"],
+        "title": "Model Inference Code",
+        "mlm:entrypoint": "package.inference:main",
+    }
+    mlm_item = pystac.Item.from_dict(mlm_data)
+    pystac.validation.validate(mlm_item, validator=mlm_validator)  # still valid
+    assert mlm_item.assets["runtime"].to_dict().get("mlm:entrypoint") == "package.inference:main"
+    assert mlm_item.assets["runtime"].roles == ["code", "mlm:source_code", "mlm:inference-runtime"]
+
+
+@pytest.mark.parametrize(
+    "mlm_example",
+    ["item_basic.json"],
+    indirect=True,
+)
+def test_mlm_entrypoint_asset_code_role_required(
+    mlm_validator: STACValidator,
+    mlm_example: dict[str, JSON],
+) -> None:
+    mlm_data = copy.deepcopy(mlm_example)
+    mlm_item = pystac.Item.from_dict(mlm_data)
+    pystac.validation.validate(mlm_item, validator=mlm_validator)  # self-check valid beforehand
+
+    mlm_data["assets"]["runtime"] = {
+        "type": "text/x-python",
+        "href": "https://example.com/package/",
+        "roles": ["mlm:inference-runtime"],
+        "title": "Model Inference Code",
+        "mlm:entrypoint": "package.inference:main",
+    }
+    mlm_item = pystac.Item.from_dict(mlm_data)
+    with pytest.raises(pystac.errors.STACValidationError) as exc:
+        pystac.validation.validate(mlm_item, validator=mlm_validator)
+    assert exc.value.source[0].instance == mlm_data["assets"]["runtime"]
+    assert "'contains': {'const': 'code'}" in str(exc.value.args)
+
+
+@pytest.mark.parametrize(
+    "mlm_example",
+    ["item_basic.json"],
+    indirect=True,
+)
+def test_mlm_entrypoint_item_disallowed(
+    mlm_validator: STACValidator,
+    mlm_example: dict[str, JSON],
+) -> None:
+    mlm_data = copy.deepcopy(mlm_example)
+    mlm_item = pystac.Item.from_dict(mlm_data)
+    pystac.validation.validate(mlm_item, validator=mlm_validator)  # self-check valid beforehand
+
+    mlm_data["properties"]["mlm:entrypoint"] = "package.inference:main"
+    mlm_item = pystac.Item.from_dict(mlm_data)
+    with pytest.raises(pystac.errors.STACValidationError) as exc:
+        pystac.validation.validate(mlm_item, validator=mlm_validator)
+    assert "Fields that are disallowed under the Item properties." in str(exc.value.args)


### PR DESCRIPTION
## Description

- fix JSON schema that rejected the `mlm:entrypoint` definition since it was missing from defined fields 
- if `mlm:entrypoint` is specified in a *Source Code Asset*, it MUST now include `code` role

## Related Issue

n/a

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :books: Examples, docs, tutorials or dependencies update;
- [x] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md) guide;
- [ ] I've updated the [`CHANGELOG.md`](https://github.com/stac-extensions/mlm/blob/main/CHANGELOG.md) with provided changes;
- [ ] I've updated the [`README.md`](https://github.com/stac-extensions/mlm/blob/main/README.md) and/or
      [`best-practices.md`](https://github.com/stac-extensions/mlm/blob/main/best-practices.md) as applicable with new features;
- [ ] I've updated the code style using `make check`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.
