### PR TITLE
add python3.13 support

### DIFF
--- a/.github/workflows/stac-model.yml
+++ b/.github/workflows/stac-model.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add official Python 3.13 support to the CI workflow and package release.
 - Add `ModelDataVariable` to `stac_model` for corresponding `mlm:input` and `mlm:output` definitions as the JSON schema.
 - Add `variables` properties to [Model Input Object](README.md#model-input-object)
   to allow specifying the relevant data variables used by the model,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Framework :: Pydantic",
     "Framework :: Pydantic :: 2",


### PR DESCRIPTION
## Description

Add python3.13 support. It was already supported as is, but it is now "officially" with CI tests and package release integration.

## Related Issue

n/a

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :books: Examples, docs, tutorials or dependencies update;
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue);
- [x] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`][contrib] guide;
- [ ] I've updated the [`CHANGELOG.md`][changes] with provided changes;
- [ ] I've updated the [`README.md`][readme] and/or [`best-practices.md`][best-practices] as applicable with new features;
- [ ] I've updated the code style using `make check`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.

[contrib]: https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md
[changes]: https://github.com/stac-extensions/mlm/blob/main/CHANGELOG.md
[readme]: https://github.com/stac-extensions/mlm/blob/main/README.md
[best-practices]: https://github.com/stac-extensions/mlm/blob/main/best-practices.md
