### PR TITLE
fix make linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,12 @@ install-dev: setup
 
 .PHONY: pre-commit-install
 pre-commit-install: setup
-	$(UV_COMMAND) run --python "$(UV_PYTHON_ROOT)" pre-commit install
+	$(UV_COMMAND) run --no-sync --python "$(UV_PYTHON_ROOT)" pre-commit install
 
 #* Formatters
 .PHONY: codestyle
 codestyle: setup
-	$(UV_COMMAND) run --python "$(UV_PYTHON_ROOT)" ruff format --config=pyproject.toml stac_model tests
+	$(UV_COMMAND) run --no-sync --python "$(UV_PYTHON_ROOT)" ruff format --config=pyproject.toml stac_model tests
 
 .PHONY: format
 format: codestyle
@@ -62,7 +62,7 @@ format: codestyle
 #* Linting
 .PHONY: test
 test: setup
-	$(UV_COMMAND) run --python "$(UV_PYTHON_ROOT)" pytest -c pyproject.toml -v --cov-report=html --cov=stac_model tests/
+	$(UV_COMMAND) run --no-sync --python "$(UV_PYTHON_ROOT)" pytest -c pyproject.toml -v --cov-report=html --cov=stac_model tests/
 
 .PHONY: check
 check: check-examples check-markdown check-lint check-mypy check-safety check-citation
@@ -72,27 +72,31 @@ check-all: check
 
 .PHONY: mypy
 mypy: setup
-	$(UV_COMMAND) run --python "$(UV_PYTHON_ROOT)" mypy --config-file pyproject.toml ./
+	$(UV_COMMAND) run --no-sync --python "$(UV_PYTHON_ROOT)" mypy --config-file pyproject.toml ./
 
 .PHONY: check-mypy
 check-mypy: mypy
 
 .PHONY: check-safety
 check-safety: setup
-	$(UV_COMMAND) run --python "$(UV_PYTHON_ROOT)" safety check --full-report
-	$(UV_COMMAND) run --python "$(UV_PYTHON_ROOT)" bandit -ll --recursive stac_model tests
+	$(UV_COMMAND) run --no-sync --python "$(UV_PYTHON_ROOT)" safety check --full-report
+	$(UV_COMMAND) run --no-sync --python "$(UV_PYTHON_ROOT)" bandit -ll --recursive stac_model tests
+
+.PHONY: check-citation
+check-citation: setup
+	$(UV_COMMAND) run --no-sync --python "$(UV_PYTHON_ROOT)" cffconvert --validate
 
 .PHONY: lint
 lint: setup
-	$(UV_COMMAND) run --python "$(UV_PYTHON_ROOT)" ruff check --fix --config=pyproject.toml ./
+	$(UV_COMMAND) run --no-sync --python "$(UV_PYTHON_ROOT)" ruff check --fix --config=pyproject.toml ./
 
 .PHONY: check-lint
 check-lint: lint
-	$(UV_COMMAND) run --python "$(UV_PYTHON_ROOT)" ruff check --config=pyproject.toml ./
+	$(UV_COMMAND) run --no-sync --python "$(UV_PYTHON_ROOT)" ruff check --config=pyproject.toml ./
 
 .PHONY: format-lint
 format-lint: lint
-	ruff format --config=pyproject.toml ./
+	$(UV_COMMAND) run --no-sync --python "$(UV_PYTHON_ROOT)" ruff check --fix --config=pyproject.toml ./
 
 .PHONY: install-npm
 install-npm:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,11 @@ dev-dependencies = [
     "types-pyyaml>=6.0.12.20250516",
     "requests>=2.32.4",
     "urllib3>=2.5.0,<3.0.0",
+    "cffconvert",
 ]
+
+[tool.uv.sources]
+cffconvert = { git = "https://github.com/citation-file-format/cffconvert.git", rev = "b6045d78aac9e02b039703b030588d54d53262ac" }
 
 [project.urls]
 homepage = "https://github.com/stac-extensions/mlm/blob/main/README_STAC_MODEL.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version < '3.13'",
@@ -74,6 +74,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507, upload-time = "2024-08-30T01:55:04.365Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321, upload-time = "2024-08-30T01:55:02.591Z" },
+]
+
+[[package]]
+name = "cffconvert"
+version = "3.0.0a0"
+source = { git = "https://github.com/citation-file-format/cffconvert.git?rev=b6045d78aac9e02b039703b030588d54d53262ac#b6045d78aac9e02b039703b030588d54d53262ac" }
+dependencies = [
+    { name = "click" },
+    { name = "jsonschema" },
+    { name = "pykwalify" },
+    { name = "requests" },
+    { name = "ruamel-yaml" },
 ]
 
 [[package]]
@@ -247,6 +259,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
 ]
+
+[[package]]
+name = "docopt"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
 
 [[package]]
 name = "docstring-parser-fork"
@@ -681,6 +699,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905, upload-time = "2024-05-04T13:42:02.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513, upload-time = "2024-05-04T13:41:57.345Z" },
+]
+
+[[package]]
+name = "pykwalify"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docopt" },
+    { name = "python-dateutil" },
+    { name = "ruamel-yaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/77/2d6849510dbfce5f74f1f69768763630ad0385ad7bb0a4f39b55de3920c7/pykwalify-1.8.0.tar.gz", hash = "sha256:796b2ad3ed4cb99b88308b533fb2f559c30fa6efb4fa9fda11347f483d245884", size = 62462, upload-time = "2020-12-30T22:31:10.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/fd/ac2161cce19fd67a18c269073f8e86292b5511acec6f8ef6eab88615d032/pykwalify-1.8.0-py2.py3-none-any.whl", hash = "sha256:731dfa87338cca9f559d1fca2bdea37299116e3139b73f78ca90a543722d6651", size = 24860, upload-time = "2020-12-30T22:31:09.09Z" },
 ]
 
 [[package]]
@@ -1203,6 +1235,7 @@ dependencies = [
 dev = [
     { name = "bandit" },
     { name = "bump-my-version" },
+    { name = "cffconvert" },
     { name = "coverage" },
     { name = "mypy" },
     { name = "mypy-extensions" },
@@ -1243,6 +1276,7 @@ requires-dist = [
 dev = [
     { name = "bandit", specifier = ">=1.7.5,<2.0.0" },
     { name = "bump-my-version", specifier = ">=0.21" },
+    { name = "cffconvert", git = "https://github.com/citation-file-format/cffconvert.git?rev=b6045d78aac9e02b039703b030588d54d53262ac" },
     { name = "coverage", specifier = ">=7.3.0,<8.0.0" },
     { name = "mypy", specifier = ">=1.0.0,<2.0.0" },
     { name = "mypy-extensions", specifier = ">=0.4.3,<1.0.0" },


### PR DESCRIPTION
## Description

- fix makefile check/lint commands to avoid uv sync 
- fix invalid run format/linter check-fix combination 
- add missing cff check-citation target

## Related Issue

@rbavery @isaaccorley 
I think the issue encountered about `pytorch` being reinstalled might be due to the missing `--no-sync` flag. I've added it in this PR, and when I run the checks locally with an outdated env, the tool does not re-install them. Given they should already be installed by the previous CI installation step, this is the intended flow.

@rbavery 
I think the issues you were encountering about differing code formatting was because `ruff format` was employed. This is different that `ruff check --fix`.

See: 
- https://github.com/astral-sh/ruff/discussions/9048
- https://docs.astral.sh/ruff/formatter/#the-ruff-formatter

Since `[tool.ruff.lint]` is used in the `pyproject.toml`, it is `ruff check --fix` that must be used since `ruff format` is configured with `[tool.ruff.format]`, and behaves differently (`black`-like) than the linter.


## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :books: Examples, docs, tutorials or dependencies update;
- [x] :wrench: Bug fix (non-breaking change which fixes an issue);
- [x] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`][contrib] guide;
- [ ] I've updated the [`CHANGELOG.md`][changes] with provided changes;
- [ ] I've updated the [`README.md`][readme] and/or [`best-practices.md`][best-practices] as applicable with new features;
- [ ] I've updated the code style using `make check`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.

[contrib]: https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md
[changes]: https://github.com/stac-extensions/mlm/blob/main/CHANGELOG.md
[readme]: https://github.com/stac-extensions/mlm/blob/main/README.md
[best-practices]: https://github.com/stac-extensions/mlm/blob/main/best-practices.md
