### PR TITLE
Bump version: stac-model 0.3.0 → 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ optional-dependencies.torch-cu126 = [
 
 # important: leave the name and version together for bump resolution
 name = "stac-model"
-version = "0.3.0"
+version = "0.4.0"
 description = "A PydanticV2 validation and serialization libary for the STAC ML Model Extension"
 readme = "README_STAC_MODEL.md"
 keywords = [

--- a/stac-model.bump.toml
+++ b/stac-model.bump.toml
@@ -6,7 +6,7 @@
 #   they are actually intented for versioning the MLM specification itself.
 #   To version 'stac-model', use the 'bump-my-version bump' operation with this file.
 #   See also https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md#building-and-releasing
-current_version = "0.3.0"
+current_version = "0.4.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/uv.lock
+++ b/uv.lock
@@ -3660,7 +3660,7 @@ wheels = [
 
 [[package]]
 name = "stac-model"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Description

Corresponding release of stac-model for the schema release #118 

This release includes pt2 export functionality with mlm metadata as well as other improvements and bug fixes noted in the CHANGELOG.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :books: Examples, docs, tutorials or dependencies update;
- [x] :wrench: Bug fix (non-breaking change which fixes an issue);
- [x] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [x] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`][contrib] guide;
- [x] I've updated the [`CHANGELOG.md`][changes] with provided changes;
- [ ] I've updated the [`README.md`][readme] and/or [`best-practices.md`][best-practices] as applicable with new features;
- [ ] I've updated the code style using `make check`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.

[contrib]: https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md
[changes]: https://github.com/stac-extensions/mlm/blob/main/CHANGELOG.md
[readme]: https://github.com/stac-extensions/mlm/blob/main/README.md
[best-practices]: https://github.com/stac-extensions/mlm/blob/main/best-practices.md
