### PR TITLE
fix case in export.save where metadata is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- n/a
+- fix case in `stac-model-torch.export` where `metadata` is None.
 
 ## [v1.5.0](https://github.com/stac-extensions/mlm/tree/v1.5.0)
 

--- a/stac_model/torch/export.py
+++ b/stac_model/torch/export.py
@@ -412,6 +412,8 @@ def save(
 
     if metadata is not None:
         metadata_properties = update_properties(metadata=metadata, input_shape=input_shape, device=device, dtype=dtype)
+    else:
+        metadata_properties = None
 
     package(
         output_file=output_file,


### PR DESCRIPTION
## Description

This fixes an issue where metadata_properties would be undefined if a user exports without MLM metadata with `stac_model.torch.export.save`

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :books: Examples, docs, tutorials or dependencies update;
- [x] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`][contrib] guide;
- [ ] I've updated the [`CHANGELOG.md`][changes] with provided changes;
- [ ] I've updated the [`README.md`][readme] and/or [`best-practices.md`][best-practices] as applicable with new features;
- [ ] I've updated the code style using `make check`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.

[contrib]: https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md
[changes]: https://github.com/stac-extensions/mlm/blob/main/CHANGELOG.md
[readme]: https://github.com/stac-extensions/mlm/blob/main/README.md
[best-practices]: https://github.com/stac-extensions/mlm/blob/main/best-practices.md
