### PR TITLE
ignore safety's own nltk vulnerability

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -22,6 +22,12 @@ security: # configuration for the `safety check` command
               false positive
               safety's own 'marshmallow' dependency that is not a vulnerability
               https://github.com/pyupio/safety/issues/826
+        "SFTY-20260616-58930":
+            reason:
+              false positive
+              safety's own 'nltk' dependency that is not a vulnerability
+              CVE-2026-54293
+              https://github.com/pyupio/safety/issues/742
         "SFTY-20250331-30014":
             reason: |
               'torch==2.10' CPU/GPU variants


### PR DESCRIPTION

## Description

CI breaks because safety needs nltk which has vulnerabilities being flagged.

Our packages do not actually need this dependency, so it can be ignored. 

## Related Issue

- https://github.com/pyupio/safety/issues/742

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :books: Examples, docs, tutorials or dependencies update;
- [ ] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [x] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`][contrib] guide;
- [ ] I've updated the [`CHANGELOG.md`][changes] with provided changes;
- [ ] I've updated the [`README.md`][readme] and/or [`best-practices.md`][best-practices] as applicable with new features;
- [ ] I've updated the code style using `make check`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.

[contrib]: https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md
[changes]: https://github.com/stac-extensions/mlm/blob/main/CHANGELOG.md
[readme]: https://github.com/stac-extensions/mlm/blob/main/README.md
[best-practices]: https://github.com/stac-extensions/mlm/blob/main/best-practices.md
