### PR TITLE
ignore U-Net example weights URI update in tests based on `torchgeo` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- n/a
+- Ignore U-Net example weights URI update in tests based on `torchgeo` version.
 
 ## [v1.5.2](https://github.com/stac-extensions/mlm/tree/v1.5.2)
 

--- a/tests/torch/test_unet_mlm.py
+++ b/tests/torch/test_unet_mlm.py
@@ -34,4 +34,9 @@ def test_unet_mlm_matches_example_json(validated_torchgeo_unet_mlm):  # pragma: 
     with open(json_path, "r", encoding="utf-8") as f:
         expected = json.load(f)
 
+    # different versions of torchgeo update model weights source repository
+    # ensure the STAC MLM Item generation is agnostic from these updates when compared to the example
+    from torchgeo.models.unet import Unet_Weights
+    expected["assets"]["model"]["href"] = Unet_Weights.SENTINEL2_2CLASS_NC_FTW.url
+
     assert validated_torchgeo_unet_mlm == expected, "Generated STAC Item does not match the saved example."


### PR DESCRIPTION
## Description

With `torchgeo>=0.10`, the U-Net used as example has a Weights URI update on Huggingface.
Since thisis not stricly necessary for validating the `stac-model` functional test, make it agnostic of specific URIs in case of future changes.

## Related Issue

- n/a

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] :books: Examples, docs, tutorials or dependencies update;
- [x] :wrench: Bug fix (non-breaking change which fixes an issue);
- [ ] :clinking_glasses: Improvement (non-breaking change which improves an existing feature);
- [ ] :rocket: New feature (non-breaking change which adds functionality);
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change);
- [ ] :closed_lock_with_key: Security fix.

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`][contrib] guide;
- [x] I've updated the [`CHANGELOG.md`][changes] with provided changes;
- [ ] I've updated the [`README.md`][readme] and/or [`best-practices.md`][best-practices] as applicable with new features;
- [x] I've updated the code style using `make check`;
- [ ] I've written tests for all new methods and classes that I created;
- [ ] I've written the docstring in `Google` format for all the methods and classes that I used.

[contrib]: https://github.com/stac-extensions/mlm/blob/main/CONTRIBUTING.md
[changes]: https://github.com/stac-extensions/mlm/blob/main/CHANGELOG.md
[readme]: https://github.com/stac-extensions/mlm/blob/main/README.md
[best-practices]: https://github.com/stac-extensions/mlm/blob/main/best-practices.md
